### PR TITLE
Fix extraction flow to use vision-only mode when ENABLE_OCR is false

### DIFF
--- a/lambda/api/app/routers/ocr.py
+++ b/lambda/api/app/routers/ocr.py
@@ -77,6 +77,8 @@ async def start_ocr_for_image(image_id: str, skip_ocr: bool = False):
 async def get_endpoint_status():
     """エンドポイントの状態を確認（ポーリング用）"""
     try:
+        if not settings.ENABLE_OCR:
+            return {"ready": True, "status": "ocr_disabled"}
         status = get_inference_component_status()
         return status
     except Exception as e:

--- a/lambda/api/app/services/extraction_service.py
+++ b/lambda/api/app/services/extraction_service.py
@@ -15,7 +15,9 @@ from utils import decimal_to_float
 from clients import s3_client
 from domains.extraction_engine import (
     extract_information_from_multi_images_with_ocr,
-    extract_information_from_single_image_with_ocr
+    extract_information_from_single_image_with_ocr,
+    extract_information_from_multi_images_without_ocr,
+    extract_information_from_single_image_without_ocr
 )
 
 logger = logging.getLogger(__name__)
@@ -70,12 +72,7 @@ class MultiImageExtractor(InformationExtractor):
             if not isinstance(converted_s3_keys, list):
                 converted_s3_keys = [converted_s3_keys]
 
-            from domains.extraction_engine import get_multipage_ocr_results
-            ocr_results = get_multipage_ocr_results(self.image_id)
-
-            if not ocr_results:
-                raise ValueError("OCR結果が見つかりません")
-
+            # S3から画像データを取得（OCR有無に関わらず必要）
             page_images = []
             content_type = 'image/jpeg'
             for s3_key in converted_s3_keys:
@@ -96,19 +93,39 @@ class MultiImageExtractor(InformationExtractor):
             if not page_images:
                 raise ValueError("画像データを取得できませんでした")
 
-            result = extract_information_from_multi_images_with_ocr(
-                page_images=page_images,
-                content_type=content_type,
-                ocr_results=ocr_results,
-                app_extraction_fields=app_extraction_fields,
-                field_names=field_names,
-                custom_prompt=custom_prompt
-            )
+            if settings.ENABLE_OCR:
+                from domains.extraction_engine import get_multipage_ocr_results
+                ocr_results = get_multipage_ocr_results(self.image_id)
+
+                if not ocr_results:
+                    raise ValueError("OCR結果が見つかりません")
+
+                result = extract_information_from_multi_images_with_ocr(
+                    page_images=page_images,
+                    content_type=content_type,
+                    ocr_results=ocr_results,
+                    app_extraction_fields=app_extraction_fields,
+                    field_names=field_names,
+                    custom_prompt=custom_prompt
+                )
+            else:
+                logger.info("OCR無効: without_ocrモードで複数画像情報抽出を実行")
+                images_data = [
+                    {'bytes': img, 'content_type': content_type}
+                    for img in page_images
+                ]
+                result = extract_information_from_multi_images_without_ocr(
+                    images_data=images_data,
+                    app_extraction_fields=app_extraction_fields,
+                    field_names=field_names,
+                    custom_prompt=custom_prompt
+                )
+                result["mapping"] = {}
 
             update_extracted_info(
                 self.image_id,
                 result["extracted_info"],
-                result["mapping"],
+                result.get("mapping", {}),
                 'completed'
             )
             update_image_status(self.image_id, "completed")
@@ -147,7 +164,6 @@ class SingleImageExtractor(InformationExtractor):
             logger.info(
                 f"処理アプリ: {app_name}, フィールド数: {len(app_extraction_fields.get('fields', []))}")
 
-            ocr_result = image_data.get("ocr_result", {})
             converted_s3_keys = image_data.get("converted_s3_key", [])
 
             if not converted_s3_keys:
@@ -166,19 +182,30 @@ class SingleImageExtractor(InformationExtractor):
             image_bytes = s3_response['Body'].read()
             content_type = s3_response.get('ContentType', 'image/jpeg')
 
-            result = extract_information_from_single_image_with_ocr(
-                image_data=image_bytes,
-                content_type=content_type,
-                ocr_result=ocr_result,
-                app_extraction_fields=app_extraction_fields,
-                field_names=field_names,
-                custom_prompt=custom_prompt
-            )
+            if settings.ENABLE_OCR:
+                ocr_result = image_data.get("ocr_result", {})
+                result = extract_information_from_single_image_with_ocr(
+                    image_data=image_bytes,
+                    content_type=content_type,
+                    ocr_result=ocr_result,
+                    app_extraction_fields=app_extraction_fields,
+                    field_names=field_names,
+                    custom_prompt=custom_prompt
+                )
+            else:
+                logger.info("OCR無効: without_ocrモードで単一画像情報抽出を実行")
+                result = extract_information_from_single_image_without_ocr(
+                    image_bytes=image_bytes,
+                    app_extraction_fields=app_extraction_fields,
+                    field_names=field_names,
+                    custom_prompt=custom_prompt
+                )
+                result["mapping"] = {}
 
             update_extracted_info(
                 self.image_id,
                 result["extracted_info"],
-                result["mapping"],
+                result.get("mapping", {}),
                 'completed'
             )
             update_image_status(self.image_id, "completed")

--- a/lambda/api/app/services/image_processing_pipeline.py
+++ b/lambda/api/app/services/image_processing_pipeline.py
@@ -5,6 +5,7 @@ OCR→情報抽出の完全フローを管理
 import logging
 from services.ocr_service import OcrService
 from services.extraction_service import ExtractionService
+from config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -19,9 +20,10 @@ class ImageProcessingPipeline:
     def process_complete_pipeline(self, image_id: str, skip_ocr: bool = False) -> None:
         """OCR→情報抽出の完全パイプラインを実行"""
         try:
-            logger.info(f"Starting pipeline for image {image_id}, skip_ocr: {skip_ocr}")
+            should_skip_ocr = skip_ocr or not settings.ENABLE_OCR
+            logger.info(f"Starting pipeline for image {image_id}, skip_ocr: {skip_ocr}, ENABLE_OCR: {settings.ENABLE_OCR}, should_skip_ocr: {should_skip_ocr}")
 
-            if not skip_ocr:
+            if not should_skip_ocr:
                 # 1. OCR処理
                 self.ocr_service.process_image_ocr(image_id)
 

--- a/lambda/api/app/services/ocr_service.py
+++ b/lambda/api/app/services/ocr_service.py
@@ -160,12 +160,13 @@ class OcrService:
     async def start_step_functions_job(self, request) -> Dict[str, Any]:
         """Step FunctionsでOCRジョブを開始する"""
         try:
-            # エンドポイント状態確認
-            status = get_inference_component_status()
-            
-            if not status['ready']:
-                trigger_endpoint_wakeup()
-                raise ValueError('endpoint_not_ready')
+            # OCR有効時のみエンドポイント状態確認
+            if self.enable_ocr:
+                status = get_inference_component_status()
+
+                if not status['ready']:
+                    trigger_endpoint_wakeup()
+                    raise ValueError('endpoint_not_ready')
             
             job_id = str(uuid.uuid4())
             app_name = request.app_name
@@ -206,10 +207,10 @@ class OcrService:
     async def start_step_functions_for_image(self, image_id: str, skip_ocr: bool = False) -> Dict[str, Any]:
         """指定画像のStep Functions OCR処理を開始する"""
         try:
-            # OCRをスキップしない場合のみエンドポイント状態確認
-            if not skip_ocr:
+            # OCRをスキップしない場合かつOCR有効時のみエンドポイント状態確認
+            if not skip_ocr and self.enable_ocr:
                 status = get_inference_component_status()
-                
+
                 if not status['ready']:
                     trigger_endpoint_wakeup()
                     raise ValueError('endpoint_not_ready')


### PR DESCRIPTION
Issue #, if available:

N/A

Description of changes:

- `image_processing_pipeline.py`: `ENABLE_OCR=false`の場合、`skip_ocr`パラメータに関わらずOCRステップを自動スキップするよう修正
- `extraction_service.py`: OCR無効時に`extract_information_from_*_without_ocr()`（Vision-onlyモード）を呼び出すよう分岐を追加。既存の`without_ocr`関数がデッドコード状態だったのを解消
- `ocr_service.py`: OCR無効時にSageMakerエンドポイントの状態チェックをスキップし、存在しないエンドポイントへのアクセスエラーを回避
- `routers/ocr.py`: `/endpoint-status`エンドポイントでOCR無効時に`{"ready": true, "status": "ocr_disabled"}`を返す修正

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
