### PR TITLE
Add yomitoku OCR engine as a third OCR option

### DIFF
--- a/lib/constructs/ocr.ts
+++ b/lib/constructs/ocr.ts
@@ -27,7 +27,7 @@ import * as path from "path";
 
 export interface OcrProps {
   baseName?: string;
-  ocrEngine?: "paddle" | "deepseek";
+  ocrEngine?: "paddle" | "deepseek" | "yomitoku";
   instanceType?: string;
   environment?: Record<string, string>;
   enableZeroScale?: boolean;
@@ -45,14 +45,18 @@ export class Ocr extends Construct {
     // デフォルト値の設定
     const baseName = props.baseName || "ocr";
     const ocrEngine = props.ocrEngine || "paddle";
-    const instanceType =
-      props.instanceType ||
-      (ocrEngine === "paddle" ? "ml.g4dn.2xlarge" : "ml.g4dn.4xlarge");
+    const instanceTypeMap: Record<string, string> = {
+      paddle: "ml.g4dn.2xlarge",
+      deepseek: "ml.g4dn.4xlarge",
+      yomitoku: "ml.g5.2xlarge",
+    };
+    const instanceType = props.instanceType || instanceTypeMap[ocrEngine] || "ml.g4dn.2xlarge";
 
     // OCRエンジンに応じたコンテナパス
-    const containerMap = {
+    const containerMap: Record<string, string> = {
       paddle: "paddle-ocr",
       deepseek: "deepseek-ocr",
+      yomitoku: "yomitoku",
     };
     const containerPath = path.join(
       __dirname,
@@ -78,6 +82,14 @@ export class Ocr extends Construct {
         TORCH_CUDA_ARCH_LIST: "8.6",
         NVIDIA_VISIBLE_DEVICES: "all",
         NVIDIA_DRIVER_CAPABILITIES: "compute,utility",
+      };
+    }
+
+    // YomiToku OCR用の追加環境変数
+    if (ocrEngine === "yomitoku") {
+      defaultEnv = {
+        ...defaultEnv,
+        PYTORCH_CUDA_ALLOC_CONF: "max_split_size_mb:512",
       };
     }
 

--- a/lib/ocr-app-stack.ts
+++ b/lib/ocr-app-stack.ts
@@ -39,7 +39,7 @@ export class OcrAppStack extends cdk.Stack {
       const ocr = new Ocr(this, "OcrEndpoint", {
         enableZeroScale: enableZeroScale,
         scaleInCooldownSeconds: scaleInCooldownSeconds,
-        ocrEngine: ocrEngine as "paddle" | "deepseek",
+        ocrEngine: ocrEngine as "paddle" | "deepseek" | "yomitoku",
       });
       ocrEndpoint = ocr;
     }

--- a/ocr-containers/yomitoku/Dockerfile
+++ b/ocr-containers/yomitoku/Dockerfile
@@ -1,0 +1,63 @@
+# NVIDIA CUDA ベースイメージを使用
+FROM nvidia/cuda:12.4.0-runtime-ubuntu22.04
+
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PYTHONUNBUFFERED=1 \
+    DEBIAN_FRONTEND=noninteractive \
+    PATH="/opt/ml/code:${PATH}"
+
+WORKDIR /opt/ml/code
+
+# 必要なパッケージをインストール
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3.10 \
+    python3-pip \
+    python3-dev \
+    python3-setuptools \
+    libgomp1 \
+    libopenblas-dev \
+    libomp-dev \
+    libjpeg-dev \
+    libpng-dev \
+    libtiff-dev \
+    libwebp-dev \
+    libgl1-mesa-glx \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender-dev \
+    git \
+    wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Python のシンボリックリンクを作成
+RUN ln -sf /usr/bin/python3.10 /usr/bin/python && \
+    ln -sf /usr/bin/python3.10 /usr/bin/python3
+
+COPY requirements.txt /opt/ml/code/
+
+# PyTorch と CUDA 関連パッケージをインストール
+RUN pip install --no-cache-dir --upgrade pip && \
+    # CUDA 12.4 対応の PyTorch をインストール
+    pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cu124 && \
+    # その他の依存関係をインストール
+    pip install --no-cache-dir -r requirements.txt
+
+# 推論コードをコピー
+COPY inference.py /opt/ml/code/
+
+# モデルキャッシュディレクトリを作成（オプショナル）
+RUN mkdir -p /root/.cache/torch/hub/checkpoints
+
+# 環境変数で GPU 使用を有効化
+ENV USE_GPU=true \
+    CUDA_VISIBLE_DEVICES=0 \
+    PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:512
+
+# SageMakerが使用するポート
+EXPOSE 8080
+
+# 推論コードを実行
+ENTRYPOINT ["python", "/opt/ml/code/inference.py"]

--- a/ocr-containers/yomitoku/inference.py
+++ b/ocr-containers/yomitoku/inference.py
@@ -1,0 +1,157 @@
+import os
+import json
+import logging
+import traceback
+import base64
+import numpy as np
+import cv2
+import torch
+from yomitoku import OCR as YomiTokuOCR
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+import uvicorn
+import sys
+
+# Logging configuration
+logger = logging.getLogger("uvicorn.error")
+logger.setLevel(logging.INFO)
+if not logger.handlers:
+    h = logging.StreamHandler(sys.stdout)
+    h.setFormatter(logging.Formatter(
+        "%(asctime)s %(levelname)s:%(name)s: %(message)s"
+    ))
+    logger.addHandler(h)
+
+app = FastAPI()
+ocr_model = None
+
+
+def load_ocr_model():
+    """Initialize YomiToku OCR model"""
+    global ocr_model
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    logger.info(f"Using device: {device}")
+
+    try:
+        ocr_model = YomiTokuOCR(visualize=False, device=device)
+        logger.info("YomiToku OCR model loaded successfully")
+        return ocr_model
+    except Exception as e:
+        logger.error(f"Error loading OCR model: {str(e)}")
+        logger.error(traceback.format_exc())
+        raise
+
+
+def parse_request_data(request_body: bytes, content_type: str):
+    """Parse request data and extract image data"""
+    logger.info(f"Parsing request - Content-Type: {content_type}")
+
+    try:
+        if content_type == 'application/json':
+            input_data = json.loads(request_body)
+            if 'image' in input_data:
+                image_data = base64.b64decode(input_data['image'])
+                return {'image_data': image_data}
+            else:
+                return {'error': 'No image field in JSON request'}
+        elif content_type and content_type.startswith('image/'):
+            return {'image_data': request_body}
+        else:
+            return {'error': f'Unsupported Content-Type: {content_type}'}
+    except Exception as e:
+        logger.error(f"Request parsing error: {str(e)}")
+        return {'error': str(e)}
+
+
+def perform_ocr(input_data, model):
+    """Perform OCR processing and return results"""
+    logger.info("Starting OCR processing")
+
+    try:
+        if 'error' in input_data:
+            return {'error': input_data['error'], 'words': []}
+
+        if 'image_data' not in input_data:
+            return {'error': 'No image data available', 'words': []}
+
+        image_data = input_data['image_data']
+        nparr = np.frombuffer(image_data, np.uint8)
+        img = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
+
+        if img is None:
+            return {'error': 'Failed to decode image', 'words': []}
+
+        logger.info("Running OCR...")
+
+        results, _ = model(img)
+
+        json_data = {"words": []}
+        if hasattr(results, 'words'):
+            for i, word in enumerate(results.words):
+                word_dict = {
+                    "id": i,
+                    "content": word.content,
+                    "direction": word.direction,
+                    "det_score": float(word.det_score),
+                    "rec_score": float(word.rec_score),
+                    "points": word.points.tolist() if hasattr(word.points, 'tolist') else word.points
+                }
+                json_data["words"].append(word_dict)
+
+        logger.info(f"OCR completed: {len(json_data['words'])} words detected")
+        return json_data
+
+    except Exception as e:
+        logger.error(f"OCR processing error: {str(e)}")
+        logger.error(traceback.format_exc())
+        return {"error": str(e), "words": []}
+
+
+@app.get("/ping")
+async def ping():
+    """Health check endpoint"""
+    logger.info("Health check requested")
+    health = ocr_model is not None
+    status = 200 if health else 404
+    return JSONResponse(
+        content={"status": "healthy" if health else "unhealthy"},
+        status_code=status
+    )
+
+
+@app.post("/invocations")
+async def invocations(request: Request):
+    """Main OCR inference endpoint"""
+    logger.info("Inference request received")
+
+    try:
+        content_type = request.headers.get('content-type')
+        request_body = await request.body()
+
+        logger.info(f"Content-Type: {content_type}, Data size: {len(request_body)} bytes")
+
+        input_data = parse_request_data(request_body, content_type)
+        prediction = perform_ocr(input_data, ocr_model)
+
+        logger.info("Returning OCR results")
+        return JSONResponse(content=prediction)
+
+    except Exception as e:
+        logger.error(f"Inference error: {str(e)}")
+        logger.error(traceback.format_exc())
+        return JSONResponse(
+            content={"error": str(e), "words": []},
+            status_code=500
+        )
+
+
+if __name__ == '__main__':
+    logger.info("Starting application...")
+
+    logger.info("Loading OCR model...")
+    load_ocr_model()
+
+    port = int(os.environ.get('PORT', 8080))
+    logger.info(f"Starting FastAPI server on port {port}")
+    uvicorn.run(app, host='0.0.0.0', port=port)

--- a/ocr-containers/yomitoku/requirements.txt
+++ b/ocr-containers/yomitoku/requirements.txt
@@ -1,0 +1,13 @@
+opencv-python-headless>=4.5.0
+numpy>=1.20.0
+Pillow>=9.0.0
+boto3>=1.28.0
+transformers
+sentencepiece
+PyMuPDF
+fastapi
+uvicorn
+sagemaker-inference>=1.0.0
+fugashi>=1.2.1
+ipadic>=1.0.0
+yomitoku


### PR DESCRIPTION
Port the yomitoku (Japanese-optimized OCR) container from the reference implementation, adapting it to use FastAPI/uvicorn to match existing container patterns. Add CDK infrastructure support with ml.g5.2xlarge instance type and CUDA 12.4 configuration.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
