### PR TITLE
fix: security hardening, bug fixes, and inline editing UI for extraction results

### DIFF
--- a/lambda/api/app/clients/dsql.py
+++ b/lambda/api/app/clients/dsql.py
@@ -12,19 +12,30 @@ logger = logging.getLogger(__name__)
 DSQL_ENDPOINT = os.environ.get("DSQL_ENDPOINT", "")
 DSQL_REGION = os.environ.get("DSQL_REGION", "")
 MAX_RETRIES = 3
+TOKEN_REFRESH_SECONDS = 10 * 60  # 10分で再接続（token有効期限15分の余裕）
 
 _conn = None
+_conn_created_at = 0.0
 
 
 def get_connection():
-    """DSQL 接続を取得（再利用）"""
-    global _conn
-    if _conn and not _conn.closed:
+    """DSQL 接続を取得（再利用、token期限前に再接続）"""
+    global _conn, _conn_created_at
+
+    token_expired = (time.time() - _conn_created_at) >= TOKEN_REFRESH_SECONDS
+
+    if _conn and not _conn.closed and not token_expired:
         try:
             _conn.cursor().execute("SELECT 1")
             return _conn
         except Exception:
             _conn = None
+
+    if _conn and not _conn.closed:
+        try:
+            _conn.close()
+        except Exception:
+            pass
 
     client = boto3.client("dsql", region_name=DSQL_REGION)
     token = client.generate_db_connect_admin_auth_token(DSQL_ENDPOINT, DSQL_REGION)
@@ -37,6 +48,7 @@ def get_connection():
         sslmode="require",
         cursor_factory=psycopg2.extras.RealDictCursor,
     )
+    _conn_created_at = time.time()
     return _conn
 
 

--- a/lambda/api/app/domains/image_status.py
+++ b/lambda/api/app/domains/image_status.py
@@ -23,3 +23,26 @@ def determine_parent_status(children: list[dict]) -> str:
         return "processing"
     else:
         return "converting"
+
+
+def determine_parent_agent_status(children: list[dict]) -> str:
+    """子ページの agent_status から親ドキュメントの agent_status を判定する
+
+    優先度: failed > processing > idle(未実行あり) > completed > skipped
+    """
+    if not children:
+        return "idle"
+
+    statuses = [child.get("agent_status") or "idle" for child in children]
+
+    if any(s == "failed" for s in statuses):
+        return "failed"
+    if any(s == "processing" for s in statuses):
+        return "processing"
+    if any(s == "idle" for s in statuses):
+        return "processing"
+    if all(s == "completed" for s in statuses):
+        return "completed"
+    if all(s == "skipped" for s in statuses):
+        return "skipped"
+    return "completed"

--- a/lambda/api/app/repositories/schema_repository.py
+++ b/lambda/api/app/repositories/schema_repository.py
@@ -177,7 +177,8 @@ def update_app_schema(app_name, app_data):
         # 現在の日時を取得
         current_time = datetime.now().isoformat()
         
-        # 既存のレコードを取得して created_at を保持
+        # 既存のレコードを取得して created_at, custom_prompt を保持
+        existing_item = {}
         try:
             existing_response = schemas_table.get_item(
                 Key={
@@ -185,9 +186,10 @@ def update_app_schema(app_name, app_data):
                     'name': app_name
                 }
             )
-            created_at = existing_response.get('Item', {}).get('created_at', current_time)
-        except:
-            created_at = current_time
+            existing_item = existing_response.get('Item', {})
+        except Exception:
+            pass
+        created_at = existing_item.get('created_at', current_time)
         
         # 新しい構造でスキーマを保存
         item = {
@@ -202,9 +204,11 @@ def update_app_schema(app_name, app_data):
             'updated_at': current_time
         }
 
-        # custom_prompt がある場合のみ追加
+        # custom_prompt: リクエストに含まれていればそれを使い、なければ既存値を保持
         if 'custom_prompt' in app_data and app_data['custom_prompt']:
             item['custom_prompt'] = app_data['custom_prompt']
+        elif existing_item.get('custom_prompt'):
+            item['custom_prompt'] = existing_item['custom_prompt']
         
         schemas_table.put_item(Item=item)
         

--- a/lambda/api/app/routers/jobs.py
+++ b/lambda/api/app/routers/jobs.py
@@ -7,7 +7,9 @@ import logging
 
 from services.agent_service import AgentService
 from dependencies.services import get_agent_service
-from dependencies.auth import require_user
+from dependencies.auth import require_user, check_usecase_permission
+from repositories.job_repository import get_job
+from repositories import get_image
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/jobs", tags=["Jobs"])
@@ -21,7 +23,18 @@ async def get_job_status(
 ):
     """ジョブステータスを取得する"""
     try:
+        job = get_job(job_id)
+        if not job:
+            raise HTTPException(status_code=404, detail="Job not found")
+
+        image = get_image(job.get("image_id", ""))
+        if not image:
+            raise HTTPException(status_code=404, detail="Associated image not found")
+        check_usecase_permission(user, image.get("app_name", ""), "viewer")
+
         return await service.get_agent_job_status(job_id)
+    except HTTPException:
+        raise
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:

--- a/lambda/api/app/services/ocr_service.py
+++ b/lambda/api/app/services/ocr_service.py
@@ -192,9 +192,7 @@ class OcrService:
         ocr_result = self._invoke_ocr(image_bytes)
 
         if "error" in ocr_result:
-            logger.error(f"OCR処理でエラーが発生: {ocr_result['error']}")
-            update_image_status(image_id, "failed")
-            return
+            raise RuntimeError(f"OCR処理でエラーが発生: {ocr_result['error']}")
 
         logger.info(f"Successfully processed {len(ocr_result.get('words', []))} words for image {image_id}")
         db_update_ocr_result(image_id, ocr_result, "processing")
@@ -277,14 +275,20 @@ class OcrService:
                 update_image_status(img['id'], 'processing', job_id)
 
             # Step Functions起動
-            execution_response = sfn_client.start_execution(
-                stateMachineArn=settings.STATE_MACHINE_ARN,
-                name=f"ocr-job-{job_id}",
-                input=json.dumps({
-                    'job_id': job_id,
-                    'images': [{'image_id': img['id']} for img in pending_images]
-                })
-            )
+            try:
+                execution_response = sfn_client.start_execution(
+                    stateMachineArn=settings.STATE_MACHINE_ARN,
+                    name=f"ocr-job-{job_id}",
+                    input=json.dumps({
+                        'job_id': job_id,
+                        'images': [{'image_id': img['id']} for img in pending_images]
+                    })
+                )
+            except Exception as sfn_error:
+                logger.error(f"Step Functions start failed, reverting image statuses: {sfn_error}")
+                for img in pending_images:
+                    update_image_status(img['id'], 'pending')
+                raise
 
             logger.info(f"Started Step Functions execution: {execution_response['executionArn']}")
 

--- a/lambda/api/app/services/pdf_conversion_service.py
+++ b/lambda/api/app/services/pdf_conversion_service.py
@@ -21,7 +21,7 @@ from repositories import (
     create_individual_page_record, get_app_input_methods,
     get_children_by_parent_id,
 )
-from domains.image_status import determine_parent_status
+from domains.image_status import determine_parent_status, determine_parent_agent_status
 from utils.helpers import resize_image
 
 logger = logging.getLogger(__name__)
@@ -220,3 +220,29 @@ def sync_parent_status(image_id: str) -> None:
 
     except Exception as e:
         logger.error(f"親ステータス更新エラー: {str(e)}")
+
+
+def sync_parent_agent_status(image_id: str) -> None:
+    """子ページの agent_status 変更後に親ドキュメントの agent_status を連動更新する"""
+    try:
+        image_data = get_image(image_id)
+        if not image_data or not image_data.get("parent_document_id"):
+            return
+
+        parent_id = image_data["parent_document_id"]
+        children = get_children_by_parent_id(parent_id)
+        new_agent_status = determine_parent_agent_status(children)
+
+        parent_data = get_image(parent_id)
+        current_agent_status = parent_data.get("agent_status") or "idle" if parent_data else "idle"
+        if current_agent_status != new_agent_status:
+            from repositories.image_repository import get_images_table
+            get_images_table().update_item(
+                Key={"id": parent_id},
+                UpdateExpression="SET agent_status = :s",
+                ExpressionAttributeValues={":s": new_agent_status},
+            )
+            logger.info(f"親ドキュメント agent_status 更新: {parent_id} -> {new_agent_status}")
+
+    except Exception as e:
+        logger.error(f"親 agent_status 更新エラー: {str(e)}")

--- a/lambda/api/app/services/s3_sync_service.py
+++ b/lambda/api/app/services/s3_sync_service.py
@@ -82,6 +82,9 @@ class S3SyncService:
             if not all([source_bucket, source_key, filename]):
                 raise ValueError("bucket, key, filename are required")
 
+            if source_bucket != self.sync_bucket_name:
+                raise ValueError("Invalid source bucket")
+
             # 重複チェック
             existing_files = get_images_by_sync_source(filename, source_key, app_name)
             if existing_files:

--- a/lambda/api/app/workers/agent_kick.py
+++ b/lambda/api/app/workers/agent_kick.py
@@ -14,6 +14,7 @@ from repositories import get_image
 from repositories.image_repository import get_images_table
 from repositories.schema_repository import get_app_schema
 from services.agent_service import AgentService
+from services.pdf_conversion_service import sync_parent_agent_status
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +65,7 @@ def agent_kick_handler(event, context):
     if not app_name:
         _update_agent_status(image_id, "skipped")
         _finalize_skipped_job(event)
+        sync_parent_agent_status(image_id)
         return {"status": "skipped", "reason": "no app_name"}
 
     # Check agent_enabled (avoid unnecessary job creation)
@@ -72,6 +74,7 @@ def agent_kick_handler(event, context):
         logger.info(f"Agent not enabled for app: {app_name}")
         _update_agent_status(image_id, "skipped")
         _finalize_skipped_job(event)
+        sync_parent_agent_status(image_id)
         return {"status": "skipped", "reason": "agent_enabled=false"}
 
     # Run agent correction directly (not via start_agent_correction to avoid re-invoke)
@@ -82,6 +85,7 @@ def agent_kick_handler(event, context):
         if not job_id:
             job_id = create_agent_job(image_id)
         _update_agent_status(image_id, "processing")
+        sync_parent_agent_status(image_id)
         agent_service = AgentService()
         asyncio.run(agent_service._process_agent_correction_async(job_id, image_id))
         # Re-read job to check actual status (may be failed internally)
@@ -94,13 +98,16 @@ def agent_kick_handler(event, context):
                 UpdateExpression="SET agent_status = :s, agent_suggestions_count = :c",
                 ExpressionAttributeValues={":s": "completed", ":c": suggestions_count},
             )
+            sync_parent_agent_status(image_id)
             return {"image_id": image_id, "status": "completed", "job_id": job_id}
         else:
             _update_agent_status(image_id, "failed")
+            sync_parent_agent_status(image_id)
             return {"image_id": image_id, "status": "failed", "job_id": job_id}
     except Exception as e:
         logger.error(f"Agent invocation failed: {e}")
         _update_agent_status(image_id, "failed")
+        sync_parent_agent_status(image_id)
         if job_id:
             try:
                 update_agent_job(job_id, "failed", error=str(e))

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 interface ToastProps {
   message: string;
@@ -8,22 +8,25 @@ interface ToastProps {
   duration?: number;
 }
 
-const Toast: React.FC<ToastProps> = ({ 
-  message, 
-  type = 'info', 
-  show, 
-  onClose, 
-  duration = 3000 
+const Toast: React.FC<ToastProps> = ({
+  message,
+  type = 'info',
+  show,
+  onClose,
+  duration = 3000
 }) => {
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   useEffect(() => {
     if (show) {
       const timer = setTimeout(() => {
-        onClose();
+        onCloseRef.current();
       }, duration);
-      
+
       return () => clearTimeout(timer);
     }
-  }, [show, duration, onClose]);
+  }, [show, duration]);
 
   if (!show) return null;
 

--- a/web/src/pages/ocr-result/ExtractedInfoDisplay.tsx
+++ b/web/src/pages/ocr-result/ExtractedInfoDisplay.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
+import { Trash2 } from 'lucide-react';
 import { Field } from '../../types/app-schema';
 import { Suggestion } from '../../types/agent';
 import { Button } from '../../components/ui';
@@ -29,6 +30,9 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
   onEnterEditMode,
 }) => {
   const [editedInfo, setEditedInfo] = useState<Record<string, any>>(extractedInfo);
+  const [expandedSuggestionRow, setExpandedSuggestionRow] = useState<string | null>(null);
+  const [editingCell, setEditingCell] = useState<string | null>(null);
+  const editInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!editMode) {
@@ -44,16 +48,6 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
     });
   };
 
-  const updateMapFieldValue = (fieldName: string, subFieldName: string, value: any) => {
-    setEditedInfo(prev => {
-      const next = {
-        ...prev,
-        [fieldName]: { ...(prev[fieldName] || {}), [subFieldName]: value }
-      };
-      onUpdateExtractedInfo(next);
-      return next;
-    });
-  };
 
   const updateListItemProperty = (fieldName: string, itemIndex: number, propertyName: string, value: any) => {
     setEditedInfo(prev => {
@@ -65,19 +59,42 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
     });
   };
 
+  const setNestedValue = (obj: any, path: string, value: any): any => {
+    const tokens: (string | number)[] = [];
+    const re = /(\w+)|\[(\d+)\]/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(path)) !== null) {
+      tokens.push(m[2] !== undefined ? parseInt(m[2], 10) : m[1]);
+    }
+    if (tokens.length === 0) return obj;
+
+    const root = Array.isArray(obj) ? [...obj] : { ...obj };
+    let cur: any = root;
+    for (let i = 0; i < tokens.length - 1; i++) {
+      const key = tokens[i];
+      const nextKey = tokens[i + 1];
+      const nextIsArray = typeof nextKey === 'number';
+      if (Array.isArray(cur[key])) {
+        cur[key] = [...cur[key]];
+      } else if (cur[key] && typeof cur[key] === 'object') {
+        cur[key] = { ...cur[key] };
+      } else {
+        cur[key] = nextIsArray ? [] : {};
+      }
+      cur = cur[key];
+    }
+    cur[tokens[tokens.length - 1]] = value;
+    return root;
+  };
+
   const handleAcceptSuggestion = (suggestion: Suggestion) => {
     if (!editMode && onEnterEditMode) {
       onEnterEditMode();
     }
-    let newInfo = { ...editedInfo };
-    const fieldPath = suggestion.field.split('.');
-    if (fieldPath.length === 1) {
-      newInfo[fieldPath[0]] = suggestion.suggested_value;
-    } else if (fieldPath.length === 2) {
-      newInfo[fieldPath[0]] = { ...(newInfo[fieldPath[0]] || {}), [fieldPath[1]]: suggestion.suggested_value };
-    }
+    const newInfo = setNestedValue(editedInfo, suggestion.field, suggestion.suggested_value);
     setEditedInfo(newInfo);
     onUpdateExtractedInfo(newInfo);
+    setExpandedSuggestionRow(null);
     onAcceptSuggestion?.(suggestion);
   };
 
@@ -85,10 +102,18 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
     if (!editMode && onEnterEditMode) {
       onEnterEditMode();
     }
+    setExpandedSuggestionRow(null);
     onRejectSuggestion?.(suggestion);
   };
 
-  const getSuggestionForField = (fieldName: string) => externalSuggestions.find(s => s.field === fieldName);
+  const getSuggestionForField = (fieldName: string) =>
+    externalSuggestions.find(s => s.field === fieldName);
+
+  const getSuggestionsForListRow = (listFieldName: string, rowIndex: number) =>
+    externalSuggestions.filter(s => {
+      const prefix = `${listFieldName}[${rowIndex}]`;
+      return s.field === prefix || s.field.startsWith(`${prefix}.`);
+    });
 
   const renderSuggestion = (suggestion: Suggestion) => (
     <div className="mt-2 p-3 bg-warning-light border border-warning-border rounded">
@@ -137,15 +162,36 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
     );
   };
 
-  const renderMapField = (field: Field) => {
+  const getValueAtPath = (path: string): any => {
+    const source = editMode ? editedInfo : extractedInfo;
+    return path.split('.').reduce((cur, key) => cur?.[key], source);
+  };
+
+  const setValueAtPath = (path: string, value: any) => {
+    const newInfo = setNestedValue(editedInfo, path, value);
+    setEditedInfo(newInfo);
+    onUpdateExtractedInfo(newInfo);
+  };
+
+  const renderMapField = (field: Field, parentPath?: string) => {
     if (!field.fields) return null;
-    const mapValue = editMode ? editedInfo[field.name] || {} : extractedInfo[field.name] || {};
+    const basePath = parentPath ? `${parentPath}.${field.name}` : field.name;
+    const mapValue = getValueAtPath(basePath) || {};
+
     return (
       <div key={field.name} className="mb-6">
         <h3 className="text-lg font-medium mb-2">{field.display_name}</h3>
         <div className="pl-4 border-l-2 border-neutral-200 space-y-3">
           {field.fields.map(subField => {
-            const fieldPath = `${field.name}.${subField.name}`;
+            const fieldPath = `${basePath}.${subField.name}`;
+
+            if (subField.type === 'map' && subField.fields) {
+              return renderMapField(subField, basePath);
+            }
+            if (subField.type === 'list' && subField.items) {
+              return renderNestedListField(subField, basePath);
+            }
+
             const suggestion = getSuggestionForField(fieldPath);
             return (
               <div key={subField.name} className="mb-3">
@@ -158,7 +204,7 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
                   <input
                     type="text"
                     value={mapValue[subField.name] || ''}
-                    onChange={(e) => updateMapFieldValue(field.name, subField.name, e.target.value)}
+                    onChange={(e) => setValueAtPath(fieldPath, e.target.value)}
                     onFocus={() => onHighlightField(fieldPath, true)}
                     className="w-full p-2 border border-neutral-300 rounded"
                   />
@@ -179,62 +225,171 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
     );
   };
 
+  const renderNestedListField = (field: Field, parentPath: string) => {
+    if (!field.items) return null;
+    const basePath = `${parentPath}.${field.name}`;
+    const listData = getValueAtPath(basePath) || [];
+
+    return (
+      <div key={field.name} className="mb-4">
+        <label className="block text-sm font-medium text-neutral-700 mb-1">{field.display_name}</label>
+        <ul className="list-disc pl-5">
+          {listData.map((item: any, i: number) => (
+            <li key={i} className="mb-1">
+              {editMode ? (
+                <input
+                  type="text"
+                  value={item || ''}
+                  onChange={(e) => {
+                    const updated = [...listData];
+                    updated[i] = e.target.value;
+                    setValueAtPath(basePath, updated);
+                  }}
+                  className="w-full p-1 border border-neutral-300 rounded text-sm"
+                />
+              ) : (
+                <span className="text-sm">{item || ''}</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  };
+
   const renderListField = (field: Field) => {
     if (!field.items) return null;
     const listData = editMode ? editedInfo[field.name] || [] : extractedInfo[field.name] || [];
 
     if (field.items.type === 'map' && field.items.fields) {
+      const itemFields = field.items.fields;
+      const colCount = itemFields.length;
+
       return (
         <div key={field.name} className="mb-6">
           <h3 className="text-lg font-medium mb-2">{field.display_name}</h3>
           <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200">
+            <table className="w-full table-fixed divide-y divide-gray-200">
+              <colgroup>
+                {itemFields.map(itemField => {
+                  const name = itemField.name.toLowerCase();
+                  let width: string;
+                  if (name === 'no' || name === 'number' || name === 'index') {
+                    width = '5%';
+                  } else if (name === 'quantity' || name === '数量' || name.includes('qty')) {
+                    width = '8%';
+                  } else if (name === 'unit' || name === '単位') {
+                    width = '7%';
+                  } else if (name.includes('price') || name.includes('単価') || name.includes('amount') || name.includes('金額')) {
+                    width = '13%';
+                  } else if (name.includes('description') || name.includes('項目') || name.includes('item') || name.includes('name')) {
+                    width = '34%';
+                  } else {
+                    width = `${Math.floor(60 / itemFields.length)}%`;
+                  }
+                  return <col key={itemField.name} style={{ width }} />;
+                })}
+              </colgroup>
               <thead className="bg-neutral-50">
                 <tr>
-                  {field.items.fields.map(itemField => (
-                    <th key={itemField.name} className={`text-left text-xs font-medium text-neutral-500 uppercase tracking-wider ${editMode ? 'px-3 py-2' : 'px-6 py-3'}`}>
+                  {itemFields.map(itemField => (
+                    <th key={itemField.name} className="px-3 py-2 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
                       {itemField.display_name}
                     </th>
                   ))}
-                  {editMode && (
-                    <th className="px-3 py-2 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">操作</th>
-                  )}
                 </tr>
               </thead>
               <tbody className="bg-bg divide-y divide-gray-200">
-                {listData.map((item: any, itemIndex: number) => (
-                  <tr key={itemIndex}>
-                    {field.items!.fields!.map(itemField => (
-                      <td key={itemField.name} className={editMode ? "px-3 py-2" : "px-6 py-4 whitespace-nowrap"}>
-                        {editMode ? (
-                          <input
-                            type="text"
-                            value={item[itemField.name] || ''}
-                            onChange={(e) => updateListItemProperty(field.name, itemIndex, itemField.name, e.target.value)}
-                            onFocus={() => onHighlightCell(field.name, itemIndex, itemField.name)}
-                            className="w-full p-1 border border-neutral-300 rounded"
-                          />
-                        ) : (
-                          <div
-                            className="text-sm text-neutral-900 cursor-pointer hover:bg-info-light p-1 rounded"
-                            onClick={() => onHighlightCell(field.name, itemIndex, itemField.name)}
-                          >
-                            {item[itemField.name] || ''}
-                          </div>
-                        )}
-                      </td>
-                    ))}
-                    {editMode && (
-                      <td className="px-3 py-2 whitespace-nowrap">
-                        <button type="button" onClick={() => {
-                          const updated = [...listData];
-                          updated.splice(itemIndex, 1);
-                          updateFieldValue(field.name, updated);
-                        }} className="text-danger hover:text-danger-text">削除</button>
-                      </td>
-                    )}
-                  </tr>
-                ))}
+                {listData.map((item: any, itemIndex: number) => {
+                  const rowSuggestions = getSuggestionsForListRow(field.name, itemIndex);
+                  const rowKey = `${field.name}[${itemIndex}]`;
+                  const isExpanded = expandedSuggestionRow === rowKey;
+
+                  return (
+                    <React.Fragment key={itemIndex}>
+                      <tr className={`group ${rowSuggestions.length > 0 ? 'bg-warning-light/30' : ''}`}>
+                        {itemFields.map((itemField, colIdx) => {
+                          const cellPath = `${field.name}[${itemIndex}].${itemField.name}`;
+                          const cellSuggestion = getSuggestionForField(cellPath);
+                          const isEditing = editingCell === cellPath;
+                          const isLastCol = colIdx === itemFields.length - 1;
+
+                          return (
+                            <td key={itemField.name} className="px-3 py-1.5 relative">
+                              {editMode && isEditing ? (
+                                <input
+                                  ref={editInputRef}
+                                  type="text"
+                                  value={item[itemField.name] || ''}
+                                  onChange={(e) => updateListItemProperty(field.name, itemIndex, itemField.name, e.target.value)}
+                                  onFocus={() => onHighlightCell(field.name, itemIndex, itemField.name)}
+                                  onBlur={() => setEditingCell(null)}
+                                  onKeyDown={(e) => { if (e.key === 'Escape' || e.key === 'Enter') setEditingCell(null); }}
+                                  className={`w-full px-2 py-1 border rounded text-sm focus:outline-none focus:ring-1 focus:ring-info ${cellSuggestion ? 'border-warning-border bg-warning-light/50' : 'border-neutral-300'}`}
+                                />
+                              ) : (
+                                <div
+                                  className={`text-sm text-neutral-900 px-2 py-1 rounded break-words cursor-pointer ${cellSuggestion ? 'text-warning-text font-medium hover:bg-warning-light/50' : 'hover:bg-info-light'}`}
+                                  onClick={() => {
+                                    onHighlightCell(field.name, itemIndex, itemField.name);
+                                    if (editMode) {
+                                      setEditingCell(cellPath);
+                                      setTimeout(() => editInputRef.current?.focus(), 0);
+                                    }
+                                    if (rowSuggestions.length > 0) {
+                                      setExpandedSuggestionRow(isExpanded ? null : rowKey);
+                                    }
+                                  }}
+                                >
+                                  {item[itemField.name] || <span className="text-neutral-400">-</span>}
+                                  {cellSuggestion && <span className="ml-1">⚠</span>}
+                                </div>
+                              )}
+                              {editMode && isLastCol && (
+                                <button
+                                  type="button"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    const updated = [...listData];
+                                    updated.splice(itemIndex, 1);
+                                    updateFieldValue(field.name, updated);
+                                  }}
+                                  className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity text-neutral-400 hover:text-danger p-1"
+                                  title="行を削除"
+                                >
+                                  <Trash2 size={14} />
+                                </button>
+                              )}
+                            </td>
+                          );
+                        })}
+                      </tr>
+                      {isExpanded && rowSuggestions.length > 0 && (
+                        <tr>
+                          <td colSpan={colCount} className="px-3 py-2 bg-warning-light/20">
+                            <div className="space-y-2">
+                              {rowSuggestions.map((suggestion, i) => (
+                                <div key={i} className="p-3 bg-warning-light border border-warning-border rounded">
+                                  <div className="text-sm mb-2">
+                                    <div className="mb-1">{suggestion.reason}</div>
+                                    <div className="text-xs text-neutral-600">
+                                      「{suggestion.original_value}」→「{suggestion.suggested_value}」
+                                      {suggestion.tool_used && <span className="ml-2">({suggestion.tool_used})</span>}
+                                    </div>
+                                  </div>
+                                  <div className="flex gap-2">
+                                    <Button variant="primary" size="sm" onClick={() => handleAcceptSuggestion(suggestion)}>採用する</Button>
+                                    <Button variant="outline" size="sm" onClick={() => handleRejectSuggestion(suggestion)}>却下</Button>
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </React.Fragment>
+                  );
+                })}
               </tbody>
             </table>
           </div>
@@ -243,7 +398,7 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
               const newItem: Record<string, string> = {};
               field.items!.fields!.forEach(f => { newItem[f.name] = ''; });
               updateFieldValue(field.name, [...listData, newItem]);
-            }} className="mt-2 text-info hover:text-info-text">+ 行を追加</button>
+            }} className="mt-2 text-info hover:text-info-text text-sm">+ 行を追加</button>
           )}
         </div>
       );

--- a/web/src/pages/ocr-result/OCRResult.tsx
+++ b/web/src/pages/ocr-result/OCRResult.tsx
@@ -81,6 +81,9 @@ function OcrResult() {
   const [agentStatus, setAgentStatus] = useState<'idle' | 'running' | 'completed'>('idle');
   const [initialAgentResult, setInitialAgentResult] = useState<any>(null);
   const [agentSuggestions, setAgentSuggestions] = useState<Suggestion[]>([]);
+  const [pendingSuggestionActions, setPendingSuggestionActions] = useState<{ index: number; status: 'accepted' | 'rejected' }[]>([]);
+  const suggestionsSnapshotRef = useRef<Suggestion[]>([]);
+  const extractedInfoSnapshotRef = useRef<Record<string, any>>({});
   const [agentFoundIssues, setAgentFoundIssues] = useState(false);
   const [showReExtractModal, setShowReExtractModal] = useState(false);
   const [showAgentModal, setShowAgentModal] = useState(false);
@@ -674,29 +677,37 @@ function OcrResult() {
     }
   }, [initialAgentResult]);
 
-  const handleAcceptSuggestion = async (suggestion: Suggestion) => {
+  const handleAcceptSuggestion = (suggestion: Suggestion) => {
+    setPendingSuggestionActions(prev => [
+      ...prev.filter(a => a.index !== suggestion.index),
+      { index: suggestion.index, status: 'accepted' },
+    ]);
     setAgentSuggestions(current => current.filter(s => s.index !== suggestion.index));
-    if (id) {
-      try {
-        await updateSuggestionStatus(id, suggestion.index, 'accepted');
-      } catch (error) {
-        console.error("提案ステータス更新エラー:", error);
-        setAgentSuggestions(current => [...current, suggestion]);
-        showToast('ステータス更新に失敗しました', 'error');
-      }
-    }
   };
 
-  const handleRejectSuggestion = async (suggestion: Suggestion) => {
+  const handleRejectSuggestion = (suggestion: Suggestion) => {
+    setPendingSuggestionActions(prev => [
+      ...prev.filter(a => a.index !== suggestion.index),
+      { index: suggestion.index, status: 'rejected' },
+    ]);
     setAgentSuggestions(current => current.filter(s => s.index !== suggestion.index));
-    if (id) {
+  };
+
+  const flushPendingSuggestionActions = async () => {
+    if (!id || pendingSuggestionActions.length === 0) return;
+    const actions = [...pendingSuggestionActions];
+    setPendingSuggestionActions([]);
+    let failedCount = 0;
+    for (const action of actions) {
       try {
-        await updateSuggestionStatus(id, suggestion.index, 'rejected');
+        await updateSuggestionStatus(id, action.index, action.status);
       } catch (error) {
         console.error("提案ステータス更新エラー:", error);
-        setAgentSuggestions(current => [...current, suggestion]);
-        showToast('ステータス更新に失敗しました', 'error');
+        failedCount++;
       }
+    }
+    if (failedCount > 0) {
+      showToast(`提案ステータスの更新に${failedCount}件失敗しました`, 'error');
     }
   };
 
@@ -1051,12 +1062,21 @@ function OcrResult() {
               <div className="flex items-center gap-2">
                 {editMode ? (
                   <>
-                    <Button variant="outline" size="sm" onClick={() => setEditMode(false)}>キャンセル</Button>
-                    <Button variant="primary" size="sm" onClick={() => { saveExtractedInfo(); setEditMode(false); }}>保存</Button>
+                    <Button variant="outline" size="sm" onClick={() => {
+                      setAgentSuggestions(suggestionsSnapshotRef.current);
+                      setExtractedInfo(extractedInfoSnapshotRef.current);
+                      setPendingSuggestionActions([]);
+                      setEditMode(false);
+                    }}>キャンセル</Button>
+                    <Button variant="primary" size="sm" onClick={async () => {
+                      await saveExtractedInfo();
+                      await flushPendingSuggestionActions();
+                      setEditMode(false);
+                    }}>保存</Button>
                   </>
                 ) : (
                   <>
-                    <Button variant="outline" size="sm" onClick={() => setEditMode(true)}>
+                    <Button variant="outline" size="sm" onClick={() => { suggestionsSnapshotRef.current = [...agentSuggestions]; extractedInfoSnapshotRef.current = { ...extractedInfo }; setEditMode(true); }}>
                       <Pencil size={14} className="mr-1" />編集
                     </Button>
                     <Button variant="outline" size="sm" onClick={handleReExtract} disabled={loading}>
@@ -1152,7 +1172,7 @@ function OcrResult() {
                     agentSuggestions={agentSuggestions}
                     onAcceptSuggestion={handleAcceptSuggestion}
                     onRejectSuggestion={handleRejectSuggestion}
-                    onEnterEditMode={() => setEditMode(true)}
+                    onEnterEditMode={() => { suggestionsSnapshotRef.current = [...agentSuggestions]; extractedInfoSnapshotRef.current = { ...extractedInfo }; setEditMode(true); }}
                   />
                 </>
               )}

--- a/web/src/pages/upload/FileList.tsx
+++ b/web/src/pages/upload/FileList.tsx
@@ -24,6 +24,7 @@ type SortField = 'uploadTime' | 'status' | 'name';
 const FileList: React.FC<FileListProps> = ({ files, onRefresh }) => {
   const navigate = useNavigate();
   const [expandedParents, setExpandedParents] = useState<Set<string>>(new Set());
+  const collapsedByUser = React.useRef<Set<string>>(new Set());
   const [deleteConfirm, setDeleteConfirm] = useState<{ show: boolean; imageId: string; imageName: string }>({
     show: false,
     imageId: '',
@@ -56,11 +57,19 @@ const FileList: React.FC<FileListProps> = ({ files, onRefresh }) => {
     });
   }, [files, filter]);
 
-  // 親ドキュメントをデフォルトで開く
+  // 新しく追加された親ドキュメントのみ展開（既存の展開状態は保持）
   React.useEffect(() => {
     const grouped = groupFiles(filteredFiles);
     const parentIds = grouped.parentDocuments.map(p => p.id);
-    setExpandedParents(new Set(parentIds));
+    setExpandedParents(prev => {
+      const next = new Set(prev);
+      for (const id of parentIds) {
+        if (!prev.has(id) && !collapsedByUser.current.has(id)) {
+          next.add(id);
+        }
+      }
+      return next;
+    });
   }, [filteredFiles]);
 
   const sortFiles = (fileList: ImageFile[]) => {
@@ -111,8 +120,10 @@ const FileList: React.FC<FileListProps> = ({ files, onRefresh }) => {
     const newExpanded = new Set(expandedParents);
     if (newExpanded.has(parentId)) {
       newExpanded.delete(parentId);
+      collapsedByUser.current.add(parentId);
     } else {
       newExpanded.add(parentId);
+      collapsedByUser.current.delete(parentId);
     }
     setExpandedParents(newExpanded);
   };


### PR DESCRIPTION
## Summary
- Fix schema update deleting custom_prompt and created_at fields
- Add S3 bucket name validation to prevent SSRF in S3 Sync
- Add permission check to agent jobs endpoint
- Add DSQL token expiry management (10min refresh)
- Fix silent OCR error handling; revert status on Step Functions start failure
- Propagate child page agent_status to parent document for individual PDFs
- Extracted info table: inline cell editing, deep nesting support, full suggestion display (#48)
- Batch suggestion accept/reject on save with snapshot restore on cancel
- Fix Toast timer reset on onClose prop change
- Fix FileList polling re-expanding user-collapsed accordions

*Issue #, if available:*
#48 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
