### PR TITLE
fix: compress oversized images before SageMaker OCR invocation

### DIFF
--- a/lambda/api/app/services/ocr_service.py
+++ b/lambda/api/app/services/ocr_service.py
@@ -15,7 +15,7 @@ from config import settings
 from clients import s3_client, sagemaker_runtime_client, sfn_client
 from domains.ocr_engine import parse_ocr_response
 from services.pdf_conversion_service import sync_parent_status
-from utils.helpers import float_to_decimal
+from utils.helpers import float_to_decimal, compress_image_for_payload
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +52,7 @@ class OcrService:
             raise ValueError("SageMaker endpoint not configured")
 
         try:
+            image_data = compress_image_for_payload(image_data)
             image_base64 = base64.b64encode(image_data).decode("utf-8")
             response = sagemaker_runtime_client.invoke_endpoint(
                 EndpointName=settings.SAGEMAKER_ENDPOINT_NAME,

--- a/lambda/api/app/utils/helpers.py
+++ b/lambda/api/app/utils/helpers.py
@@ -80,3 +80,47 @@ def resize_image(image_data, max_dimension=1568, min_dimension=200):
         logger.error(f"画像リサイズエラー: {str(e)}")
         # エラーの場合は元の画像を返す
         return image_data, False, None, None
+
+
+MAX_PAYLOAD_IMAGE_BYTES = 4 * 1024 * 1024  # 4MB (base64で~5.3MB、6MB制限内に収まる)
+
+
+def compress_image_for_payload(image_data: bytes, max_bytes: int = MAX_PAYLOAD_IMAGE_BYTES) -> bytes:
+    """SageMaker invoke_endpoint の 6MB ペイロード制限に収まるよう画像を圧縮する"""
+    if len(image_data) <= max_bytes:
+        return image_data
+
+    logger.info(f"画像サイズ超過: {len(image_data)} bytes → {max_bytes} bytes 以下に圧縮")
+
+    try:
+        img = Image.open(BytesIO(image_data))
+        img_format = img.format or 'JPEG'
+
+        if img_format != 'JPEG':
+            if img.mode in ('RGBA', 'P'):
+                img = img.convert('RGB')
+            img_format = 'JPEG'
+
+        for quality in [85, 75, 60, 45, 30]:
+            output = BytesIO()
+            img.save(output, format='JPEG', quality=quality, optimize=True)
+            if output.tell() <= max_bytes:
+                logger.info(f"圧縮完了: quality={quality}, size={output.tell()} bytes")
+                return output.getvalue()
+
+        width, height = img.size
+        for scale in [0.75, 0.5, 0.35]:
+            new_size = (int(width * scale), int(height * scale))
+            resized = img.resize(new_size, Image.LANCZOS)
+            output = BytesIO()
+            resized.save(output, format='JPEG', quality=45, optimize=True)
+            if output.tell() <= max_bytes:
+                logger.info(f"圧縮完了: scale={scale}, size={output.tell()} bytes")
+                return output.getvalue()
+
+        logger.warning(f"最大圧縮でも目標サイズ未達: {output.tell()} bytes")
+        return output.getvalue()
+
+    except Exception as e:
+        logger.error(f"画像圧縮エラー: {str(e)}")
+        return image_data


### PR DESCRIPTION
*Issue #, if available:*
#51 

*Description of changes:*
Handle SageMaker invoke_endpoint 6MB payload limit. Before base64 encoding, check image byte size and compress if it exceeds 4MB (effective limit accounting for ~33% base64 overhead + JSON wrapper).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
