### PR TITLE
feat: support Yomitoku Pro (AWS Marketplace) as ocrEngine option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,16 @@ const envOverrides: Record<string, Partial<AppParameters>> = {
 
 `lib/parameters.ts` の `modelId` と `modelRegion` を変更してください。モデルの ID は [Amazon Bedrock でサポートされている基盤モデル](https://docs.aws.amazon.com/ja_jp/bedrock/latest/userguide/models-supported.html) を参照してください。また、使用するモデルを変更する場合は、モデルアクセスを有効化する必要があります。
 
-#### OCR エンジンへの変更(PaddleOCR or DeepSeek OCR)
+#### OCR エンジンの変更
 
 `lib/parameters.ts` の `ocrEngine` を変更してください。
 
-- `paddle`: PaddleOCR（デフォルト）
-- `deepseek`: DeepSeek OCR
+- `paddle`: PaddleOCR（デフォルト）— 自前コンテナ、ゼロスケール対応
+- `deepseek`: DeepSeek OCR — 自前コンテナ、ゼロスケール対応
+- `yomitoku-mp`: Yomitoku Pro（AWS Marketplace）— 高精度日本語 OCR
+
+> [!Note]
+> OCR エンジンを切り替える際、既存のエンドポイントと新しいエンドポイントで InferenceComponent の有無が異なる場合（例: `paddle` → `yomitoku-mp`）、インプレース更新ができません。一度 `enableOcr: false` でデプロイしてから `enableOcr: true` に戻して再デプロイしてください。
 
 ### CDK による AWS リソースのデプロイ
 
@@ -149,15 +153,28 @@ cdk destroy
 - `sagemakerZeroScale`: ゼロスケーリング機能の有効/無効（デフォルト: `true`）
 - `sagemakerScaleInCooldownSeconds`: スケールダウンまでの待機時間（秒）（デフォルト: `3600` = 1時間）
 
-## 高精度日本語 OCR エンジンへの変更
+## 高精度日本語 OCR エンジン（Yomitoku）
 
-デフォルトでは OCR エンジンとして PaddleOCR を利用していますが、高精度の日本語 OCR エンジン「Yomitoku」に切り替えることも可能です。Yomitoku の場合は、[AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-64qkuwrqi4lhi) からサブスクライブした後、利用することが可能です。利用方法としては、[ocr.py](lambda/api/app/ocr.py#L36) における SageMaker Endpoint の呼び出しにおいて、Yomitoku の SageMaker Endpoint を指定します。また、[Inference Component](lambda/api/app/ocr.py#L40) の記述をコメントアウトする必要があります。DeepSeek OCR に切り替えたい場合は、[OCR エンジンへの変更(PaddleOCR or DeepSeek OCR)](#ocr-エンジンへの変更paddleocr-or-deepseek-ocr) をご参照ください。
+デフォルトでは OCR エンジンとして PaddleOCR を利用していますが、高精度の日本語 OCR エンジン「Yomitoku Pro」に切り替えることが可能です。
 
-また、GitHub で公開されている [Yomitoku](https://github.com/kotaro-kinoshita/yomitoku) を利用して、本サンプルを動作させることも可能です。実装例については[こちら](https://github.com/gteu/sample-auto-extract-ai-ocr-app)を参照してください。
+### AWS Marketplace 版（yomitoku-mp）
+
+[AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-64qkuwrqi4lhi) からサブスクライブ後、`lib/parameters.ts` で以下を設定するだけで利用できます。
+
+```typescript
+ocrEngine: "yomitoku-mp",
+marketplaceModelPackageArn: "arn:aws:sagemaker:<region>:<account>:model-package/yomitoku-pro-document-analyzer-...",
+sagemakerZeroScale: false, // Marketplace モデルはゼロスケール非対応
+```
+
+Marketplace 版は InferenceComponent を使用しないため、ゼロスケーリングには対応していません。エンドポイントは常時起動（ml.g5.xlarge: 約 $1.7/h）となります。
+
+### OSS 版（yomitoku）
+
+GitHub で公開されている [Yomitoku](https://github.com/kotaro-kinoshita/yomitoku) を利用した実装例は[こちら](https://github.com/gteu/sample-auto-extract-ai-ocr-app)を参照してください。
 
 > [!Warning]
->
-> GitHub 版の Yomitoku は CC BY-NC-SA 4.0 ライセンスが適用されます（[詳細](https://github.com/kotaro-kinoshita/yomitoku?tab=readme-ov-file#license)）。このライセンスでは商用利用が制限されているため、ご注意ください。
+> OSS 版の Yomitoku は CC BY-NC-SA 4.0 ライセンスが適用されます（[詳細](https://github.com/kotaro-kinoshita/yomitoku?tab=readme-ov-file#license)）。商用利用が制限されているためご注意ください。
 
 ## AI Agent による情報検証機能（Experimental）
 

--- a/lambda/api/app/clients/__init__.py
+++ b/lambda/api/app/clients/__init__.py
@@ -8,7 +8,7 @@ from .aws import (
     create_bedrock_agentcore_client, create_dynamodb_resource, create_sfn_client,
     s3_client, bedrock_client, dynamodb_client, dynamodb_resource,
     sagemaker_runtime_client, sagemaker_client, bedrock_agentcore_client, sfn_client,
-    get_inference_component_status, trigger_endpoint_wakeup,
+    get_inference_component_status, get_endpoint_status_direct, trigger_endpoint_wakeup,
 )
 from .agent import AgentClient
 from .bedrock import call_bedrock, call_bedrock_with_retry
@@ -21,5 +21,5 @@ __all__ = [
     "sagemaker_runtime_client", "sagemaker_client", "bedrock_agentcore_client", "sfn_client",
     "AgentClient",
     "call_bedrock", "call_bedrock_with_retry",
-    "get_inference_component_status", "trigger_endpoint_wakeup",
+    "get_inference_component_status", "get_endpoint_status_direct", "trigger_endpoint_wakeup",
 ]

--- a/lambda/api/app/clients/aws.py
+++ b/lambda/api/app/clients/aws.py
@@ -92,6 +92,16 @@ def get_inference_component_status(component_name: str) -> dict:
     }
 
 
+def get_endpoint_status_direct(endpoint_name: str) -> dict:
+    """InferenceComponent を使わないエンドポイントの状態取得（Marketplace モデル用）"""
+    response = sagemaker_client.describe_endpoint(EndpointName=endpoint_name)
+    status = response['EndpointStatus']
+    return {
+        'ready': status == 'InService',
+        'status': status.lower(),
+    }
+
+
 def trigger_endpoint_wakeup(endpoint_name: str, component_name: str):
     """エンドポイントのスケールアウトをトリガー（ダミーリクエスト送信）"""
     try:

--- a/lambda/api/app/config.py
+++ b/lambda/api/app/config.py
@@ -26,6 +26,7 @@ class Settings:
         "SAGEMAKER_ENDPOINT_NAME", "")
     SAGEMAKER_INFERENCE_COMPONENT_NAME: str = os.getenv(
         "SAGEMAKER_INFERENCE_COMPONENT_NAME", "")
+    OCR_ENGINE: str = os.getenv("OCR_ENGINE", "paddle")
 
     # API設定
     API_BASE_URL: str = os.getenv("API_BASE_URL", "")

--- a/lambda/api/app/domains/ocr_engine.py
+++ b/lambda/api/app/domains/ocr_engine.py
@@ -44,3 +44,30 @@ def parse_ocr_response(response_body: dict) -> dict:
         "words": words,
         "word_count": len(words),
     }
+
+
+def parse_yomitoku_mp_response(response_body: dict) -> dict:
+    """Yomitoku Marketplace レスポンスを既存 OCR 結果形式に変換する"""
+    if "error" in response_body:
+        logger.error(f"Yomitoku MP エラー: {response_body['error']}")
+        return {"error": response_body["error"], "text": "", "words": [], "word_count": 0}
+
+    results = response_body.get("result", [])
+    if not results:
+        logger.error("Yomitoku MP: レスポンスに result フィールドがありません")
+        return {"error": "No result from Yomitoku", "text": "", "words": [], "word_count": 0}
+
+    all_words = []
+    word_id = 0
+    for page_result in results:
+        for word in page_result.get("words", []):
+            all_words.append({
+                "id": word_id,
+                "content": word["content"],
+                "points": word["points"],
+                "direction": word.get("direction", "horizontal"),
+            })
+            word_id += 1
+
+    full_text = " ".join(w["content"] for w in all_words)
+    return {"text": full_text, "words": all_words, "word_count": len(all_words)}

--- a/lambda/api/app/services/ocr_service.py
+++ b/lambda/api/app/services/ocr_service.py
@@ -9,15 +9,26 @@ from repositories import (
     get_image, update_ocr_result as db_update_ocr_result,
     update_image_status,
 )
-from clients import get_inference_component_status, trigger_endpoint_wakeup
+from clients import get_inference_component_status, get_endpoint_status_direct, trigger_endpoint_wakeup
 from schemas import OcrResult, OcrResultResponse
 from config import settings
 from clients import s3_client, sagemaker_runtime_client, sfn_client
-from domains.ocr_engine import parse_ocr_response
+from domains.ocr_engine import parse_ocr_response, parse_yomitoku_mp_response
 from services.pdf_conversion_service import sync_parent_status
 from utils.helpers import float_to_decimal, compress_image_for_payload
 
 logger = logging.getLogger(__name__)
+
+
+def _guess_image_content_type(image_data: bytes) -> str:
+    """画像バイナリのマジックバイトから Content-Type を判定する"""
+    if image_data[:3] == b'\xff\xd8\xff':
+        return "image/jpeg"
+    if image_data[:8] == b'\x89PNG\r\n\x1a\n':
+        return "image/png"
+    if image_data[:4] in (b'II*\x00', b'MM\x00*'):
+        return "image/tiff"
+    return "image/jpeg"
 
 
 class EndpointNotReadyError(Exception):
@@ -35,21 +46,19 @@ class OcrService:
         """OCR エンドポイントの状態を返す"""
         if not self.enable_ocr:
             return {"ready": True, "status": "ocr_disabled"}
+        if settings.OCR_ENGINE == "yomitoku-mp":
+            return get_endpoint_status_direct(settings.SAGEMAKER_ENDPOINT_NAME)
         return get_inference_component_status(settings.SAGEMAKER_INFERENCE_COMPONENT_NAME)
 
     def _invoke_ocr(self, image_data: bytes) -> dict:
-        """SageMaker OCR エンドポイントを呼び出し、整形済み結果を返す
-
-        Args:
-            image_data: 画像のバイトデータ
-
-        Returns:
-            整形済み OCR 結果
-        """
+        """SageMaker OCR エンドポイントを呼び出し、整形済み結果を返す"""
         if not self.enable_ocr:
             raise ValueError("OCR is disabled in this deployment")
         if not settings.SAGEMAKER_ENDPOINT_NAME:
             raise ValueError("SageMaker endpoint not configured")
+
+        if settings.OCR_ENGINE == "yomitoku-mp":
+            return self._invoke_yomitoku_mp(image_data)
 
         try:
             image_data = compress_image_for_payload(image_data)
@@ -64,6 +73,22 @@ class OcrService:
             return parse_ocr_response(response_body)
         except Exception as e:
             logger.error(f"SageMaker OCR 呼び出しエラー: {str(e)}")
+            return {"error": f"SageMaker endpoint error: {str(e)}", "text": "", "words": [], "word_count": 0}
+
+    def _invoke_yomitoku_mp(self, image_data: bytes) -> dict:
+        """Yomitoku Marketplace エンドポイントを呼び出す"""
+        try:
+            image_data = compress_image_for_payload(image_data, max_bytes=5 * 1024 * 1024)
+            content_type = _guess_image_content_type(image_data)
+            response = sagemaker_runtime_client.invoke_endpoint(
+                EndpointName=settings.SAGEMAKER_ENDPOINT_NAME,
+                ContentType=content_type,
+                Body=image_data,
+            )
+            response_body = json.loads(response["Body"].read().decode("utf-8"))
+            return parse_yomitoku_mp_response(response_body)
+        except Exception as e:
+            logger.error(f"Yomitoku MP 呼び出しエラー: {str(e)}")
             return {"error": f"SageMaker endpoint error: {str(e)}", "text": "", "words": [], "word_count": 0}
 
     async def get_ocr_result(self, image_id: str) -> OcrResultResponse:
@@ -252,10 +277,11 @@ class OcrService:
         try:
             # OCR有効時のみエンドポイント状態確認
             if self.enable_ocr:
-                status = get_inference_component_status(settings.SAGEMAKER_INFERENCE_COMPONENT_NAME)
+                status = self.get_endpoint_status()
 
                 if not status['ready']:
-                    trigger_endpoint_wakeup(settings.SAGEMAKER_ENDPOINT_NAME, settings.SAGEMAKER_INFERENCE_COMPONENT_NAME)
+                    if settings.OCR_ENGINE != "yomitoku-mp":
+                        trigger_endpoint_wakeup(settings.SAGEMAKER_ENDPOINT_NAME, settings.SAGEMAKER_INFERENCE_COMPONENT_NAME)
                     raise EndpointNotReadyError('Endpoint warming up')
 
             job_id = str(uuid.uuid4())
@@ -304,10 +330,11 @@ class OcrService:
         try:
             # OCRをスキップしない場合かつOCR有効時のみエンドポイント状態確認
             if not skip_ocr and self.enable_ocr:
-                status = get_inference_component_status(settings.SAGEMAKER_INFERENCE_COMPONENT_NAME)
+                status = self.get_endpoint_status()
 
                 if not status['ready']:
-                    trigger_endpoint_wakeup(settings.SAGEMAKER_ENDPOINT_NAME, settings.SAGEMAKER_INFERENCE_COMPONENT_NAME)
+                    if settings.OCR_ENGINE != "yomitoku-mp":
+                        trigger_endpoint_wakeup(settings.SAGEMAKER_ENDPOINT_NAME, settings.SAGEMAKER_INFERENCE_COMPONENT_NAME)
                     raise EndpointNotReadyError('Endpoint warming up')
 
             job_id = str(uuid.uuid4())

--- a/lib/constructs/api.ts
+++ b/lib/constructs/api.ts
@@ -35,6 +35,7 @@ export interface ApiProps {
   userPoolId: string;
   userPoolClientId: string;
   enableOcr: boolean;
+  ocrEngine?: string;
   sagemakerEndpointName?: string;
   sagemakerInferenceComponentName?: string;
   agentRuntimeArn?: string;
@@ -121,6 +122,7 @@ export class Api extends Construct {
           actions: [
             "sagemaker:InvokeEndpoint",
             "sagemaker:DescribeInferenceComponent",
+            "sagemaker:DescribeEndpoint",
           ],
           resources: ["*"],
         })
@@ -185,6 +187,7 @@ export class Api extends Construct {
         SAGEMAKER_ENDPOINT_NAME: props.sagemakerEndpointName || "",
         SAGEMAKER_INFERENCE_COMPONENT_NAME:
           props.sagemakerInferenceComponentName || "",
+        OCR_ENGINE: props.ocrEngine || "paddle",
         MODEL_ID: modelId,
         MODEL_REGION: modelRegion,
         AGENT_RUNTIME_ARN: props.agentRuntimeArn || "",

--- a/lib/constructs/ocr.ts
+++ b/lib/constructs/ocr.ts
@@ -27,11 +27,12 @@ import * as path from "path";
 
 export interface OcrProps {
   baseName?: string;
-  ocrEngine?: "paddle" | "deepseek";
+  ocrEngine?: "paddle" | "deepseek" | "yomitoku-mp";
   instanceType?: string;
   environment?: Record<string, string>;
   enableZeroScale?: boolean;
   scaleInCooldownSeconds?: number;
+  marketplaceModelPackageArn?: string;
 }
 
 export class Ocr extends Construct {
@@ -45,47 +46,30 @@ export class Ocr extends Construct {
     // デフォルト値の設定
     const baseName = props.baseName || "ocr";
     const ocrEngine = props.ocrEngine || "paddle";
+    const isMarketplace = ocrEngine === "yomitoku-mp";
+
+    if (isMarketplace && props.enableZeroScale) {
+      throw new Error("sagemakerZeroScale is not supported with yomitoku-mp (Marketplace models do not support InferenceComponent)");
+    }
+
     const instanceType =
       props.instanceType ||
-      (ocrEngine === "paddle" ? "ml.g4dn.2xlarge" : "ml.g4dn.4xlarge");
+      (isMarketplace
+        ? "ml.g5.xlarge"
+        : ocrEngine === "paddle"
+        ? "ml.g4dn.2xlarge"
+        : "ml.g4dn.4xlarge");
 
-    // OCRエンジンに応じたコンテナパス
-    const containerMap = {
+    // OCRエンジンに応じたコンテナパス（Marketplace は不要）
+    const containerMap: Record<string, string> = {
       paddle: "paddle-ocr",
       deepseek: "deepseek-ocr",
     };
-    const containerPath = path.join(
-      __dirname,
-      `../../ocr-containers/${containerMap[ocrEngine] || ocrEngine}`
-    );
 
     const variantName = "AllTraffic";
-    this.inferenceComponentName = `${baseName}-inference-component`;
-
-    // OCRエンジン用のデフォルト環境変数
-    let defaultEnv: Record<string, string> = {
-      USE_GPU: "true",
-      CUDA_VISIBLE_DEVICES: "0",
-      OCR_ENGINE: ocrEngine,
-    };
-
-    // DeepSeek OCR用の追加環境変数
-    if (ocrEngine === "deepseek") {
-      defaultEnv = {
-        ...defaultEnv,
-        CROP_MODE: "true",
-        MODEL_PATH: "deepseek-ai/DeepSeek-OCR",
-        TORCH_CUDA_ARCH_LIST: "8.6",
-        NVIDIA_VISIBLE_DEVICES: "all",
-        NVIDIA_DRIVER_CAPABILITIES: "compute,utility",
-      };
-    }
-
-    // デフォルトと指定された環境変数をマージ
-    const environment = {
-      ...defaultEnv,
-      ...(props.environment || {}),
-    };
+    this.inferenceComponentName = isMarketplace
+      ? ""
+      : `${baseName}-inference-component`;
 
     // SageMaker用のIAMロール
     const sagemakerRole = new Role(this, "SageMakerExecutionRole", {
@@ -96,7 +80,6 @@ export class Ocr extends Construct {
       ],
     });
 
-    // CloudWatch Logsの許可を追加
     sagemakerRole.addToPolicy(
       new PolicyStatement({
         actions: [
@@ -112,7 +95,6 @@ export class Ocr extends Construct {
       })
     );
 
-    // ECRへの認証許可を追加
     sagemakerRole.addToPolicy(
       new PolicyStatement({
         actions: ["ecr:GetAuthorizationToken"],
@@ -120,33 +102,90 @@ export class Ocr extends Construct {
       })
     );
 
-    // コンテナイメージのビルドとECRへのプッシュ
-    const dockerImage = new DockerImageAsset(this, "OcrDockerImage", {
-      directory: containerPath,
-      buildArgs: {},
-      exclude: [".git", "node_modules"],
-      platform: Platform.LINUX_AMD64,
-    });
+    let model: CfnModel;
 
-    const model = new CfnModel(this, "OcrModel", {
-      modelName: containerMap[ocrEngine],
-      executionRoleArn: sagemakerRole.roleArn,
-      primaryContainer: {
-        image: dockerImage.imageUri,
-        environment: environment,
-      },
-    });
+    if (isMarketplace) {
+      // Marketplace モデル（Yomitoku-Pro）: ModelPackage ARN を使用
+      if (!props.marketplaceModelPackageArn) {
+        throw new Error(
+          "marketplaceModelPackageArn is required for yomitoku-mp engine"
+        );
+      }
+      model = new CfnModel(this, "OcrModel", {
+        executionRoleArn: sagemakerRole.roleArn,
+        enableNetworkIsolation: true,
+        primaryContainer: {
+          modelPackageName: props.marketplaceModelPackageArn,
+        },
+      });
+    } else {
+      // 自前コンテナ（PaddleOCR / DeepSeek）
+      const containerPath = path.join(
+        __dirname,
+        `../../ocr-containers/${containerMap[ocrEngine] || ocrEngine}`
+      );
+
+      let defaultEnv: Record<string, string> = {
+        USE_GPU: "true",
+        CUDA_VISIBLE_DEVICES: "0",
+        OCR_ENGINE: ocrEngine,
+      };
+
+      if (ocrEngine === "deepseek") {
+        defaultEnv = {
+          ...defaultEnv,
+          CROP_MODE: "true",
+          MODEL_PATH: "deepseek-ai/DeepSeek-OCR",
+          TORCH_CUDA_ARCH_LIST: "8.6",
+          NVIDIA_VISIBLE_DEVICES: "all",
+          NVIDIA_DRIVER_CAPABILITIES: "compute,utility",
+        };
+      }
+
+      const environment = {
+        ...defaultEnv,
+        ...(props.environment || {}),
+      };
+
+      const dockerImage = new DockerImageAsset(this, "OcrDockerImage", {
+        directory: containerPath,
+        buildArgs: {},
+        exclude: [".git", "node_modules"],
+        platform: Platform.LINUX_AMD64,
+      });
+
+      model = new CfnModel(this, "OcrModel", {
+        modelName: containerMap[ocrEngine],
+        executionRoleArn: sagemakerRole.roleArn,
+        primaryContainer: {
+          image: dockerImage.imageUri,
+          environment: environment,
+        },
+      });
+
+      new cdk.CfnOutput(this, "DockerImageUri", {
+        value: dockerImage.imageUri,
+        description: "ECRのDockerイメージURI",
+      });
+    }
 
     const endpointConfig = new CfnEndpointConfig(this, "OcrEndpointConfig", {
-      executionRoleArn: sagemakerRole.roleArn,
+      ...(isMarketplace ? {} : { executionRoleArn: sagemakerRole.roleArn }),
       productionVariants: [
         {
           variantName: variantName,
+          ...(isMarketplace
+            ? { modelName: model.attrModelName }
+            : {}),
           instanceType: instanceType,
           initialInstanceCount: 1,
-          routingConfig: {
-            routingStrategy: "LEAST_OUTSTANDING_REQUESTS",
-          },
+          ...(isMarketplace
+            ? {}
+            : {
+                routingConfig: {
+                  routingStrategy: "LEAST_OUTSTANDING_REQUESTS",
+                },
+              }),
           containerStartupHealthCheckTimeoutInSeconds: 600,
           modelDataDownloadTimeoutInSeconds: 600,
         },
@@ -158,110 +197,105 @@ export class Ocr extends Construct {
     });
 
     this.endpointName = endpoint.attrEndpointName;
-
     endpoint.addDependency(endpointConfig);
 
-    // OCRエンジンに応じたリソース要件
-    let cpuCores = 1;
-    let memoryMb = 4096;
-    let acceleratorDevices = 1;
+    // InferenceComponent + Auto Scaling（Marketplace 以外のみ）
+    if (!isMarketplace) {
+      let cpuCores = 1;
+      let memoryMb = 4096;
+      let acceleratorDevices = 1;
 
-    if (ocrEngine === "deepseek") {
-      cpuCores = 8;
-      memoryMb = 42768;
-      acceleratorDevices = 1;
-    }
-
-    const inferenceComponent = new CfnInferenceComponent(
-      this,
-      "OcrInferenceComponent",
-      {
-        inferenceComponentName: this.inferenceComponentName,
-        endpointName: endpoint.attrEndpointName,
-        variantName: variantName,
-        specification: {
-          modelName: model.attrModelName,
-          computeResourceRequirements: {
-            numberOfAcceleratorDevicesRequired: acceleratorDevices,
-            numberOfCpuCoresRequired: cpuCores,
-            minMemoryRequiredInMb: memoryMb,
-          },
-        },
-        runtimeConfig: {
-          copyCount: 1,
-        },
+      if (ocrEngine === "deepseek") {
+        cpuCores = 8;
+        memoryMb = 42768;
+        acceleratorDevices = 1;
       }
-    );
 
-    inferenceComponent.addDependency(endpoint);
-    inferenceComponent.addDependency(model);
+      const inferenceComponent = new CfnInferenceComponent(
+        this,
+        "OcrInferenceComponent",
+        {
+          inferenceComponentName: this.inferenceComponentName,
+          endpointName: endpoint.attrEndpointName,
+          variantName: variantName,
+          specification: {
+            modelName: model.attrModelName,
+            computeResourceRequirements: {
+              numberOfAcceleratorDevicesRequired: acceleratorDevices,
+              numberOfCpuCoresRequired: cpuCores,
+              minMemoryRequiredInMb: memoryMb,
+            },
+          },
+          runtimeConfig: {
+            copyCount: 1,
+          },
+        }
+      );
 
-    // Auto Scaling設定（ゼロスケール）
-    if (props.enableZeroScale) {
-      const resourceId = `inference-component/${this.inferenceComponentName}`;
+      inferenceComponent.addDependency(endpoint);
+      inferenceComponent.addDependency(model);
 
-      const scalableTarget = new ScalableTarget(this, "ScalableTarget", {
-        serviceNamespace: ServiceNamespace.SAGEMAKER,
-        scalableDimension: "sagemaker:inference-component:DesiredCopyCount",
-        resourceId: resourceId,
-        minCapacity: 0,
-        maxCapacity: 1,
-      });
+      if (props.enableZeroScale) {
+        const resourceId = `inference-component/${this.inferenceComponentName}`;
 
-      scalableTarget.node.addDependency(inferenceComponent);
+        const scalableTarget = new ScalableTarget(this, "ScalableTarget", {
+          serviceNamespace: ServiceNamespace.SAGEMAKER,
+          scalableDimension: "sagemaker:inference-component:DesiredCopyCount",
+          resourceId: resourceId,
+          minCapacity: 0,
+          maxCapacity: 1,
+        });
 
-      // ターゲットトラッキングポリシー（スケールイン用）
-      new TargetTrackingScalingPolicy(this, "TargetTrackingPolicy", {
-        scalingTarget: scalableTarget,
-        targetValue: 1,
-        predefinedMetric:
-          PredefinedMetric.SAGEMAKER_INFERENCE_COMPONENT_INVOCATIONS_PER_COPY,
-        scaleInCooldown: cdk.Duration.seconds(
-          props.scaleInCooldownSeconds || 3600
-        ),
-        scaleOutCooldown: cdk.Duration.seconds(60),
-      });
+        scalableTarget.node.addDependency(inferenceComponent);
 
-      // ステップスケーリングポリシー（スケールアウト用）
-      const noCapacityMetric = new Metric({
-        namespace: "AWS/SageMaker",
-        metricName: "NoCapacityInvocationFailures",
-        dimensionsMap: {
-          InferenceComponentName: this.inferenceComponentName,
-        },
-        statistic: "Maximum",
-        period: cdk.Duration.seconds(60),
-      });
+        new TargetTrackingScalingPolicy(this, "TargetTrackingPolicy", {
+          scalingTarget: scalableTarget,
+          targetValue: 1,
+          predefinedMetric:
+            PredefinedMetric.SAGEMAKER_INFERENCE_COMPONENT_INVOCATIONS_PER_COPY,
+          scaleInCooldown: cdk.Duration.seconds(
+            props.scaleInCooldownSeconds || 3600
+          ),
+          scaleOutCooldown: cdk.Duration.seconds(60),
+        });
 
-      new StepScalingPolicy(this, "StepScalingPolicy", {
-        scalingTarget: scalableTarget,
-        adjustmentType: AdjustmentType.CHANGE_IN_CAPACITY,
-        metricAggregationType: MetricAggregationType.MAXIMUM,
-        cooldown: cdk.Duration.seconds(60),
-        scalingSteps: [
-          { change: 1, lower: 0 },
-          { change: 0, upper: -1 },
-        ],
-        metric: noCapacityMetric,
-      });
+        const noCapacityMetric = new Metric({
+          namespace: "AWS/SageMaker",
+          metricName: "NoCapacityInvocationFailures",
+          dimensionsMap: {
+            InferenceComponentName: this.inferenceComponentName,
+          },
+          statistic: "Maximum",
+          period: cdk.Duration.seconds(60),
+        });
+
+        new StepScalingPolicy(this, "StepScalingPolicy", {
+          scalingTarget: scalableTarget,
+          adjustmentType: AdjustmentType.CHANGE_IN_CAPACITY,
+          metricAggregationType: MetricAggregationType.MAXIMUM,
+          cooldown: cdk.Duration.seconds(60),
+          scalingSteps: [
+            { change: 1, lower: 0 },
+            { change: 0, upper: -1 },
+          ],
+          metric: noCapacityMetric,
+        });
+      }
     }
 
     this.sagemakerRoleArn = sagemakerRole.roleArn;
-
-    new cdk.CfnOutput(this, "DockerImageUri", {
-      value: dockerImage.imageUri,
-      description: "ECRのDockerイメージURI",
-    });
 
     new cdk.CfnOutput(this, "SageMakerEndpointName", {
       value: this.endpointName,
       description: "SageMakerエンドポイント名",
     });
 
-    new cdk.CfnOutput(this, "SageMakerInferenceComponentName", {
-      value: this.inferenceComponentName,
-      description: "SageMaker推論コンポーネント名",
-    });
+    if (!isMarketplace) {
+      new cdk.CfnOutput(this, "SageMakerInferenceComponentName", {
+        value: this.inferenceComponentName,
+        description: "SageMaker推論コンポーネント名",
+      });
+    }
 
     new cdk.CfnOutput(this, "SageMakerRoleArn", {
       value: this.sagemakerRoleArn,

--- a/lib/constructs/step-functions.ts
+++ b/lib/constructs/step-functions.ts
@@ -18,6 +18,7 @@ export interface StepFunctionsProps {
   schemasTable: cdk.aws_dynamodb.Table;
   documentBucket: cdk.aws_s3.Bucket;
   enableOcr: boolean;
+  ocrEngine?: string;
   sagemakerEndpointName?: string;
   sagemakerInferenceComponentName?: string;
   modelId: string;
@@ -55,6 +56,7 @@ export class StepFunctions extends Construct {
         ENABLE_OCR: props.enableOcr.toString(),
         SAGEMAKER_ENDPOINT_NAME: props.sagemakerEndpointName || '',
         SAGEMAKER_INFERENCE_COMPONENT_NAME: props.sagemakerInferenceComponentName || '',
+        OCR_ENGINE: props.ocrEngine || 'paddle',
       },
     });
     

--- a/lib/ocr-app-stack.ts
+++ b/lib/ocr-app-stack.ts
@@ -50,6 +50,7 @@ export class OcrAppStack extends cdk.Stack {
         enableZeroScale: p.sagemakerZeroScale,
         scaleInCooldownSeconds: p.sagemakerScaleInCooldownSeconds,
         ocrEngine: p.ocrEngine,
+        marketplaceModelPackageArn: p.marketplaceModelPackageArn,
       });
       ocrEndpoint = ocr;
     }
@@ -75,6 +76,7 @@ export class OcrAppStack extends cdk.Stack {
       userPoolId: auth.userPool.userPoolId,
       userPoolClientId: auth.client.userPoolClientId,
       enableOcr: p.enableOcr,
+      ocrEngine: p.ocrEngine,
       sagemakerEndpointName: ocrEndpoint?.endpointName,
       sagemakerInferenceComponentName: ocrEndpoint?.inferenceComponentName,
       agentRuntimeArn: agent?.runtimeArn,
@@ -91,6 +93,7 @@ export class OcrAppStack extends cdk.Stack {
       schemasTable: database.schemasTable,
       documentBucket: api.documentBucket,
       enableOcr: p.enableOcr,
+      ocrEngine: p.ocrEngine,
       sagemakerEndpointName: ocrEndpoint?.endpointName,
       sagemakerInferenceComponentName: ocrEndpoint?.inferenceComponentName,
       modelId: p.modelId,

--- a/lib/parameters.ts
+++ b/lib/parameters.ts
@@ -16,9 +16,10 @@ export interface AppParameters {
 
   // OCR
   enableOcr: boolean;
-  ocrEngine: "paddle" | "deepseek";
+  ocrEngine: "paddle" | "deepseek" | "yomitoku-mp";
   sagemakerZeroScale: boolean;
   sagemakerScaleInCooldownSeconds: number;
+  marketplaceModelPackageArn?: string;
 
   // Agent
   enableAgent: boolean;


### PR DESCRIPTION
*Issue #, if available:*
#54

*Description of changes:*
Add `ocrEngine: "yomitoku-mp"` as a new OCR engine option using the Yomitoku Pro model from AWS Marketplace.

- Binary payload invocation (no InferenceComponent, no base64 encoding)
- CDK: Marketplace model with `enableNetworkIsolation`, synth-time validation for incompatible params
- Backend: Marketplace response parser, endpoint status check via `DescribeEndpoint`, content-type detection from magic bytes
- Docs: README updated with Marketplace setup instructions and engine switching notes

Note: Switching between IC-based engines (paddle/deepseek) and Marketplace (yomitoku-mp) requires a two-step deploy (`enableOcr: false` → `true`) due to SageMaker endpoint update restrictions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

