### PR TITLE
fix: UI improvements - empty field display, back button placement, app name

### DIFF
--- a/web/src/components/layout/AppLayout.tsx
+++ b/web/src/components/layout/AppLayout.tsx
@@ -18,7 +18,7 @@ export function AppLayout() {
         style={{ position: 'sticky', top: 0, zIndex: 1000 }}
       >
         <div className="flex items-center gap-2">
-          <Link to="/" className="font-semibold text-sm hover:text-neutral-200">OCR App</Link>
+          <Link to="/" className="font-semibold text-sm hover:text-neutral-200">AutoExtract</Link>
           {currentAppName && (
             <>
               <span className="text-neutral-300 text-sm">/</span>

--- a/web/src/pages/ocr-result/ExtractedInfoDisplay.tsx
+++ b/web/src/pages/ocr-result/ExtractedInfoDisplay.tsx
@@ -151,10 +151,10 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
           />
         ) : (
           <div
-            className="p-2 bg-neutral-50 border border-neutral-200 rounded cursor-pointer hover:bg-neutral-100"
+            className="p-2 bg-neutral-50 border border-neutral-200 rounded cursor-pointer hover:bg-neutral-100 min-h-[2.5rem]"
             onClick={() => onHighlightField(field.name, true)}
           >
-            {value || '(抽出されませんでした)'}
+            {value || ''}
           </div>
         )}
         {suggestion && renderSuggestion(suggestion)}
@@ -210,10 +210,10 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
                   />
                 ) : (
                   <div
-                    className="p-2 bg-neutral-50 border border-neutral-200 rounded cursor-pointer hover:bg-neutral-100"
+                    className="p-2 bg-neutral-50 border border-neutral-200 rounded cursor-pointer hover:bg-neutral-100 min-h-[2.5rem]"
                     onClick={() => onHighlightField(fieldPath, true)}
                   >
-                    {mapValue[subField.name] || '(抽出されませんでした)'}
+                    {mapValue[subField.name] || ''}
                   </div>
                 )}
                 {suggestion && renderSuggestion(suggestion)}
@@ -341,7 +341,7 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
                                     }
                                   }}
                                 >
-                                  {item[itemField.name] || <span className="text-neutral-400">-</span>}
+                                  {item[itemField.name] || ''}
                                   {cellSuggestion && <span className="ml-1">⚠</span>}
                                 </div>
                               )}

--- a/web/src/pages/ocr-result/OCRResult.tsx
+++ b/web/src/pages/ocr-result/OCRResult.tsx
@@ -1058,6 +1058,13 @@ function OcrResult() {
 
           <div className={styles.header}>
             <h2 className={styles.title}>{currentViewTitle}</h2>
+            {activeView === "ocr" && (
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" onClick={() => changeView("extraction")}>
+                  <ArrowLeft size={14} className="mr-1" />抽出結果
+                </Button>
+              </div>
+            )}
             {activeView === "extraction" && extractionStatus === "completed" && (
               <div className="flex items-center gap-2">
                 {editMode ? (
@@ -1113,11 +1120,6 @@ function OcrResult() {
               {isOcrEnabled() ? (
                 ocrWords.length > 0 ? (
                   <>
-                    <div className="mb-4 p-2">
-                      <Button variant="secondary" onClick={() => changeView("extraction")}>
-                        抽出画面へ戻る
-                      </Button>
-                    </div>
                     <OcrResultEditor
                       ocrResults={ocrWords}
                       selectedIndex={selectedIndex}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Remove "(抽出されませんでした)" text from empty fields to avoid confusion with actual extracted content. Empty fields now display as blank with consistent height.
- Move "抽出画面へ戻る" button to the header and unify style with other action buttons (outline, sm, ArrowLeft icon).
- Rename header app name from "OCR App" to "AutoExtract".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
