### PR TITLE
Fix/sagemaker engine switch instance type

### DIFF
--- a/lambda/api/app/repositories/image_repository.py
+++ b/lambda/api/app/repositories/image_repository.py
@@ -92,24 +92,61 @@ def create_image_record(image_id, filename, s3_key, app_name="default", status="
         raise
 
 
+# 一覧表示に必要なフィールドのみ取得する（ocr_result/extracted_info/extraction_mapping
+# などの重いフィールドは詳細画面で個別取得するため一覧では除外する）。
+# ImageInfo(schemas/image.py) が必要とする DynamoDB 属性キー（snake_case）に対応。
+# status / name は DynamoDB 予約語のため ExpressionAttributeNames でエスケープする。
+_IMAGE_LIST_PROJECTION = (
+    "id, filename, s3_key, upload_time, #status, job_id, app_name, "
+    "page_processing_mode, total_pages, page_number, parent_document_id, "
+    "verification_completed, agent_status, agent_suggestions_count, "
+    "uploaded_by, verified_by"
+)
+_IMAGE_LIST_EXPR_NAMES = {"#status": "status"}
+
+
+def _paginate(operation, **kwargs):
+    """query/scan を LastEvaluatedKey が尽きるまで繰り返し、全 Items を返す。
+
+    DynamoDB は1回のレスポンスで最大1MB（scan/query 共通）までしか返さないため、
+    継続トークン(ExclusiveStartKey)を渡して全件を取得する。
+
+    Args:
+        operation: table.query または table.scan
+        **kwargs: operation に渡すパラメータ
+
+    Returns:
+        list: 全ページ分の Items を連結したリスト
+    """
+    items = []
+    while True:
+        response = operation(**kwargs)
+        items.extend(response.get('Items', []))
+        last_key = response.get('LastEvaluatedKey')
+        if not last_key:
+            break
+        kwargs['ExclusiveStartKey'] = last_key
+    return items
+
+
 def get_images(app_name=None, uploaded_by=None):
     """
-    画像一覧を取得する
+    画像一覧を取得する（ページネーションで全件取得）
 
     Args:
         app_name (str, optional): アプリケーション名でフィルタリング
                                  指定時はGSI(AppNameIndex)でquery実行
-                                 未指定時はscanで全件取得（1MB制限あり）
+                                 未指定時はscanで全件取得
         uploaded_by (str, optional): アップロードユーザーの cognito_sub でフィルタリング
                                     指定時はGSI(UploadedByIndex)でquery実行
 
     Returns:
-        list: 画像レコードのリスト
+        list: 画像レコードのリスト（一覧表示用フィールドのみ）
 
     注意:
-        app_name/uploaded_by未指定時はDynamoDB scanを使用するため、1MBのデータサイズ制限があります。
-        大量のレコードがある場合、全てのデータを取得できない可能性があります。
-        本番環境では必ずapp_nameを指定してGSI経由でのquery使用を推奨します。
+        DynamoDB は scan/query いずれも1レスポンス最大1MBの制限があるため、
+        LastEvaluatedKey を辿って全件を取得する。
+        一覧に不要な重いフィールド(ocr_result 等)は ProjectionExpression で除外している。
     """
     table = get_images_table()
 
@@ -117,37 +154,46 @@ def get_images(app_name=None, uploaded_by=None):
         if uploaded_by and app_name:
             # UploadedByIndex で取得し、app_name でクライアント側フィルタ
             # （GSI の PK が uploaded_by のみのため、app_name は KeyCondition に含められない）
-            response = table.query(
+            items = _paginate(
+                table.query,
                 IndexName="UploadedByIndex",
                 KeyConditionExpression=Key('uploaded_by').eq(uploaded_by),
+                ProjectionExpression=_IMAGE_LIST_PROJECTION,
+                ExpressionAttributeNames=_IMAGE_LIST_EXPR_NAMES,
                 ScanIndexForward=False  # 降順（新しい順）
             )
-            items = [i for i in response.get('Items', []) if i.get('app_name') == app_name]
+            items = [i for i in items if i.get('app_name') == app_name]
             logger.info("UploadedByIndex + app_name フィルタで画像を取得")
         elif uploaded_by:
             # UploadedByIndex で自分の画像のみ取得
-            response = table.query(
+            items = _paginate(
+                table.query,
                 IndexName="UploadedByIndex",
                 KeyConditionExpression=Key('uploaded_by').eq(uploaded_by),
+                ProjectionExpression=_IMAGE_LIST_PROJECTION,
+                ExpressionAttributeNames=_IMAGE_LIST_EXPR_NAMES,
                 ScanIndexForward=False  # 降順（新しい順）
             )
-            items = response.get('Items', [])
             logger.info("UploadedByIndex 経由でユーザーの画像を取得")
         elif app_name:
             # GSI(AppNameIndex)を使用してアプリ名でフィルタリング
-            # queryは効率的で1MB制限の影響を受けにくい
-            response = table.query(
+            items = _paginate(
+                table.query,
                 IndexName="AppNameIndex",
                 KeyConditionExpression=Key('app_name').eq(app_name),
+                ProjectionExpression=_IMAGE_LIST_PROJECTION,
+                ExpressionAttributeNames=_IMAGE_LIST_EXPR_NAMES,
                 ScanIndexForward=False  # 降順（新しい順）
             )
-            items = response.get('Items', [])
             logger.info(f"GSI経由でアプリ '{app_name}' の画像を取得")
         else:
-            # 全件取得（警告: DynamoDB scanは1MB制限があり、大規模データでは不完全な結果になる）
-            response = table.scan()
-            items = response.get('Items', [])
-            logger.warning("scanで全件取得中 - 大量データがある場合は一部のレコードが取得されない可能性があります")
+            # 全件取得（scan もページネーションで全件取得する）
+            items = _paginate(
+                table.scan,
+                ProjectionExpression=_IMAGE_LIST_PROJECTION,
+                ExpressionAttributeNames=_IMAGE_LIST_EXPR_NAMES,
+            )
+            logger.info("scanで全画像を取得")
 
         # DynamoDB の Item をそのまま返す（camelCase 変換はサービス層/Pydantic で行う）
         return items
@@ -345,15 +391,17 @@ def delete_images_by_app_name(app_name: str):
     try:
         table = get_images_table()
 
-        # GSIを使用してアプリ名でクエリ
-        response = table.query(
+        # GSIを使用してアプリ名でクエリ（ページネーションで全件取得）
+        items = _paginate(
+            table.query,
             IndexName="AppNameIndex",
-            KeyConditionExpression=Key('app_name').eq(app_name)
+            KeyConditionExpression=Key('app_name').eq(app_name),
+            ProjectionExpression="id",
         )
 
         # 取得した画像を削除
         deleted_count = 0
-        for item in response.get('Items', []):
+        for item in items:
             table.delete_item(Key={'id': item['id']})
             deleted_count += 1
 
@@ -549,10 +597,10 @@ def get_children_by_parent_id(parent_id: str):
     table = get_images_table()
 
     try:
-        response = table.scan(
+        return _paginate(
+            table.scan,
             FilterExpression=Attr('parent_document_id').eq(parent_id)
         )
-        return response.get('Items', [])
     except Exception as e:
         logger.error(f"子ページ取得エラー: {str(e)}")
         return []
@@ -600,8 +648,7 @@ def get_images_by_sync_source(filename: str, sync_source_path: str, app_name: st
         if app_name:
             filter_expression = filter_expression & Attr('app_name').eq(app_name)
 
-        response = table.scan(FilterExpression=filter_expression)
-        return response.get('Items', [])
+        return _paginate(table.scan, FilterExpression=filter_expression)
 
     except Exception as e:
         logger.error(f"同期元パスでの画像検索エラー: {str(e)}")
@@ -610,19 +657,18 @@ def get_images_by_sync_source(filename: str, sync_source_path: str, app_name: st
 def get_existing_sync_sources(app_name: str) -> set[str]:
     """指定アプリの既存 sync_source_path のセットを返す（バッチ重複チェック用）
 
-    1 回の scan で全件取得し、Python 側でセット化する。
+    scan をページネーションで全件取得し、Python 側でセット化する。
     ファイルごとに scan するより効率的。
-
-    警告: DynamoDB scan は 1MB 制限があり、大量データでは不完全な結果になる可能性がある。
     """
     try:
         table = get_images_table()
         filter_expr = Attr("app_name").eq(app_name) & Attr("sync_source_path").exists()
-        response = table.scan(
+        items = _paginate(
+            table.scan,
             FilterExpression=filter_expr,
             ProjectionExpression="sync_source_path",
         )
-        return {item["sync_source_path"] for item in response.get("Items", [])}
+        return {item["sync_source_path"] for item in items}
     except Exception as e:
         logger.error(f"同期元パス一括取得エラー: {str(e)}")
         return set()

--- a/lambda/api/app/services/ocr_service.py
+++ b/lambda/api/app/services/ocr_service.py
@@ -20,6 +20,11 @@ from utils.helpers import float_to_decimal, compress_image_for_payload
 
 logger = logging.getLogger(__name__)
 
+# Step Functions StartExecution の入力ペイロードは 256KB 上限。
+# 1 画像あたり {"image_id": "<uuid>"} ≒ 55-60 バイトのため、余裕をもって
+# 1 実行あたりの画像数を制限する（2000 件で約 120KB 相当）。
+MAX_IMAGES_PER_EXECUTION = 2000
+
 
 def _guess_image_content_type(image_data: bytes) -> str:
     """画像バイナリのマジックバイトから Content-Type を判定する"""
@@ -297,6 +302,17 @@ class OcrService:
             if not pending_images:
                 logger.warning(f"No pending images found for app: {app_name}")
                 return {"jobId": job_id}
+
+            # Step Functions の StartExecution 入力は 256KB 制限がある。
+            # 1 実行あたりの画像数を上限で切り、超過分は pending のまま残して
+            # 次回実行で処理させる（入力ペイロード超過による起動失敗を防ぐ）。
+            if len(pending_images) > MAX_IMAGES_PER_EXECUTION:
+                logger.warning(
+                    f"Pending images ({len(pending_images)}) exceed per-execution limit "
+                    f"({MAX_IMAGES_PER_EXECUTION}) for app: {app_name}. "
+                    f"Processing first {MAX_IMAGES_PER_EXECUTION}; remainder stays pending for the next run."
+                )
+                pending_images = pending_images[:MAX_IMAGES_PER_EXECUTION]
 
             # ステータスを更新
             for img in pending_images:

--- a/lib/constructs/ocr.ts
+++ b/lib/constructs/ocr.ts
@@ -60,6 +60,13 @@ export class Ocr extends Construct {
         ? "ml.g4dn.2xlarge"
         : "ml.g4dn.4xlarge");
 
+    // InstanceType を論理ID・固定名に埋め込むためのサフィックス。
+    // InstanceType を変更すると論理IDが変わり、CloudFormation が
+    // Endpoint/EndpointConfig/InferenceComponent を「別リソース」として
+    // 新規作成→旧削除（Replacement）するため、InferenceComponent 付き
+    // エンドポイントの「InstanceType 変更不可」制約を1デプロイで回避できる。
+    const itSuffix = instanceType.replace(/[^a-zA-Z0-9]/g, "");
+
     // OCRエンジンに応じたコンテナパス（Marketplace は不要）
     const containerMap: Record<string, string> = {
       paddle: "paddle-ocr",
@@ -67,9 +74,10 @@ export class Ocr extends Construct {
     };
 
     const variantName = "AllTraffic";
+    // InstanceType をサフィックスに含め、作り直し時に新旧の名前が衝突しないようにする
     this.inferenceComponentName = isMarketplace
       ? ""
-      : `${baseName}-inference-component`;
+      : `${baseName}-inference-component-${itSuffix}`;
 
     // SageMaker用のIAMロール
     const sagemakerRole = new Role(this, "SageMakerExecutionRole", {
@@ -169,7 +177,7 @@ export class Ocr extends Construct {
       });
     }
 
-    const endpointConfig = new CfnEndpointConfig(this, "OcrEndpointConfig", {
+    const endpointConfig = new CfnEndpointConfig(this, `OcrEndpointConfig${itSuffix}`, {
       ...(isMarketplace ? {} : { executionRoleArn: sagemakerRole.roleArn }),
       productionVariants: [
         {
@@ -192,7 +200,7 @@ export class Ocr extends Construct {
       ],
     });
 
-    const endpoint = new CfnEndpoint(this, "OcrEndpoint", {
+    const endpoint = new CfnEndpoint(this, `OcrEndpoint${itSuffix}`, {
       endpointConfigName: endpointConfig.attrEndpointConfigName,
     });
 
@@ -213,7 +221,7 @@ export class Ocr extends Construct {
 
       const inferenceComponent = new CfnInferenceComponent(
         this,
-        "OcrInferenceComponent",
+        `OcrInferenceComponent${itSuffix}`,
         {
           inferenceComponentName: this.inferenceComponentName,
           endpointName: endpoint.attrEndpointName,
@@ -238,7 +246,7 @@ export class Ocr extends Construct {
       if (props.enableZeroScale) {
         const resourceId = `inference-component/${this.inferenceComponentName}`;
 
-        const scalableTarget = new ScalableTarget(this, "ScalableTarget", {
+        const scalableTarget = new ScalableTarget(this, `ScalableTarget${itSuffix}`, {
           serviceNamespace: ServiceNamespace.SAGEMAKER,
           scalableDimension: "sagemaker:inference-component:DesiredCopyCount",
           resourceId: resourceId,
@@ -248,7 +256,7 @@ export class Ocr extends Construct {
 
         scalableTarget.node.addDependency(inferenceComponent);
 
-        new TargetTrackingScalingPolicy(this, "TargetTrackingPolicy", {
+        new TargetTrackingScalingPolicy(this, `TargetTrackingPolicy${itSuffix}`, {
           scalingTarget: scalableTarget,
           targetValue: 1,
           predefinedMetric:
@@ -269,7 +277,7 @@ export class Ocr extends Construct {
           period: cdk.Duration.seconds(60),
         });
 
-        new StepScalingPolicy(this, "StepScalingPolicy", {
+        new StepScalingPolicy(this, `StepScalingPolicy${itSuffix}`, {
           scalingTarget: scalableTarget,
           adjustmentType: AdjustmentType.CHANGE_IN_CAPACITY,
           metricAggregationType: MetricAggregationType.MAXIMUM,


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This PR fixes two independent bugs.

### 1. Fix SageMaker deployment failure when switching OCR engines (`lib/constructs/ocr.ts`)

**Problem**: Switching `ocrEngine` (paddle ↔ deepseek ↔ yomitoku) automatically changes the SageMaker instance type based on each engine's default. However, endpoints with an attached InferenceComponent reject an `UpdateEndpoint` that changes the instance type, so deployments failed with:

```
Cannot update endpoint with a different instance type for endpoints to which
you plan to deploy Inference Components.
```

The only workaround was a manual two-step deploy: deploy with `enableOcr: false`, then set it back to `true` and deploy again.

**Fix**: The instance type is now embedded into the logical IDs (construct ids) of the EndpointConfig / Endpoint / InferenceComponent / AutoScaling resources, as well as into the InferenceComponent name. When the instance type changes, the logical IDs change, so CloudFormation treats them as new resources and performs a Replacement (create new → delete old) in a single deploy. Because it no longer goes through the "update existing endpoint" path, it does not hit the constraint above.

- Instance type changes now complete in a single deploy (no manual two-step)
- Logical IDs are unchanged as long as the instance type is the same, so normal updates behave as before
- Note: the few minutes of downtime for endpoint recreation is inherent to SageMaker and remains

### 2. Fix incomplete image list count (`lambda/api/app/repositories/`, `services/`)

**Problem**: The image list was capped by DynamoDB's 1 MB per-response limit, so it returned fewer records than actually exist. This limit applies to GSI queries as well as scans, but no continuation via `LastEvaluatedKey` was implemented.

**Fix**:
- Added a `_paginate` helper that follows `LastEvaluatedKey` to retrieve all items, and applied it to `get_images()`
- Excluded heavy fields not needed by the list view (`ocr_result` / `extracted_info` / `extraction_mapping`) via `ProjectionExpression` to reduce response size
- Unified four sibling functions with the same truncation bug (`delete_images_by_app_name`, `get_children_by_parent_id`, `get_images_by_sync_source`, `get_existing_sync_sources`) to use `_paginate`
- Capped the number of images per execution when starting an OCR batch, since passing all pending images to the Step Functions input can exceed the 256 KB limit


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
