### PR TITLE
fix: pin paddlepaddle 3.2.1 and paddleocr 3.7.0 for PP-OCRv6 compatibility

### DIFF
--- a/ocr-containers/paddle-ocr/Dockerfile
+++ b/ocr-containers/paddle-ocr/Dockerfile
@@ -33,15 +33,16 @@ RUN ln -sf /usr/bin/python3.10 /usr/bin/python && \
 RUN pip install --no-cache-dir --upgrade pip
 
 # Install PaddlePaddle GPU version
-RUN pip install --no-cache-dir paddlepaddle-gpu==3.0.0 \
+# PP-OCRv6（paddleocr 3.7.0）は paddlepaddle 3.2.1 以上が必要
+RUN pip install --no-cache-dir paddlepaddle-gpu==3.2.1 \
     -i https://www.paddlepaddle.org.cn/packages/stable/cu118/
 
 # Install Python packages
 COPY requirements.txt /opt/ml/code/
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Install PaddleOCR
-RUN pip install --no-cache-dir paddleocr>=3.0.0
+# Install PaddleOCR（バージョン固定。>= だと再ビルド時に最新へ揺れ、paddlepaddle と非互換になる）
+RUN pip install --no-cache-dir paddleocr==3.7.0
 
 # Copy inference code
 COPY inference.py /opt/ml/code/


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

The OCR SageMaker endpoint failed to start, crash-looping during PaddleOCR initialization with:

    ValueError: (InvalidArgument) Type of attribute: strides is not right.

This caused the InferenceComponent ping health check to fail and the whole CloudFormation stack to roll back, so OCR was completely unavailable.

Root cause: a version mismatch introduced by an unpinned dependency.
- `ocr-containers/paddle-ocr/Dockerfile` installed `paddleocr>=3.0.0` (no upper bound) while pinning `paddlepaddle-gpu==3.0.0`.
- On a recent rebuild, `paddleocr>=3.0.0` resolved to the latest release (3.7.0), which defaults to the new PP-OCRv6 models. Those models' inference graph is not readable by the pinned paddlepaddle 3.0.0 (the `strides` attribute type differs), so `create_predictor` failed at startup.

Fix (both versions now pinned so rebuilds are reproducible):
- `paddlepaddle-gpu==3.0.0` -> `paddlepaddle-gpu==3.2.1` (required by PP-OCRv6 / paddleocr 3.7.0).
- `paddleocr>=3.0.0` -> `paddleocr==3.7.0`.

Verified by redeploying: the OCR endpoint and its InferenceComponent both reach `InService` (previously the InferenceComponent failed its health check and rolled back).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
