### PR TITLE
fix: snapshot extraction schema per image to prevent stale-schema crashes

### DIFF
--- a/lambda/api/app/repositories/image_repository.py
+++ b/lambda/api/app/repositories/image_repository.py
@@ -259,7 +259,7 @@ def update_ocr_result(image_id: str, ocr_result: dict) -> None:
         raise
 
 
-def update_extracted_info(image_id, extracted_info, extraction_mapping):
+def update_extracted_info(image_id, extracted_info, extraction_mapping, extracted_fields=None):
     """
     抽出情報を更新する（Map型で保存）
 
@@ -267,17 +267,25 @@ def update_extracted_info(image_id, extracted_info, extraction_mapping):
         image_id (str): 画像ID
         extracted_info (dict): 抽出情報
         extraction_mapping (dict): 抽出マッピング
+        extracted_fields (list, optional): 抽出時点のスキーマ（fields）のスナップショット。
+            抽出実行時のみ渡す。手動編集の保存では渡さず、既存スナップショットを保持する。
     """
     table = get_images_table()
+
+    update_expression = "SET extracted_info = :extracted_info, extraction_mapping = :extraction_mapping"
+    expression_attribute_values = {
+        ":extracted_info": extracted_info,
+        ":extraction_mapping": extraction_mapping,
+    }
+    if extracted_fields is not None:
+        update_expression += ", extracted_fields = :extracted_fields"
+        expression_attribute_values[":extracted_fields"] = extracted_fields
 
     try:
         table.update_item(
             Key={"id": image_id},
-            UpdateExpression="SET extracted_info = :extracted_info, extraction_mapping = :extraction_mapping",
-            ExpressionAttributeValues={
-                ":extracted_info": extracted_info,
-                ":extraction_mapping": extraction_mapping
-            }
+            UpdateExpression=update_expression,
+            ExpressionAttributeValues=expression_attribute_values
         )
         logger.info(f"抽出情報を更新しました: {image_id}")
     except Exception as e:

--- a/lambda/api/app/services/extraction_service.py
+++ b/lambda/api/app/services/extraction_service.py
@@ -123,7 +123,8 @@ class InformationExtractor(ABC):
             update_extracted_info(
                 self.image_id,
                 result["extracted_info"],
-                result.get("mapping", {})
+                result.get("mapping", {}),
+                extracted_fields=app_extraction_fields.get("fields", [])
             )
             update_image_status(self.image_id, "completed")
 
@@ -279,8 +280,8 @@ class ExtractionService:
                 raise ValueError(f"app_name not found for image {image_id}")
 
             app_display_name = get_app_display_name(app_name)
-            app_extraction_fields = get_extraction_fields_for_app(app_name)[
-                "fields"]
+            # snapshot 側と型を揃えて比較・返却するため現スキーマも Decimal→float 正規化する
+            current_fields = decimal_to_float(get_extraction_fields_for_app(app_name)["fields"])
 
             status = image_data.get("status")
             if status != "completed":
@@ -291,10 +292,22 @@ class ExtractionService:
                     "status": status,
                     "app_name": app_name,
                     "app_display_name": app_display_name,
-                    "fields": app_extraction_fields,
+                    "fields": current_fields,
+                    "schema_changed": False,
                     "verification_completed": image_data.get("verification_completed", False),
                     "verification_completed_at": image_data.get("verification_completed_at")
                 }
+
+            # 抽出時点のスキーマ（スナップショット）があればそれで表示する。
+            # 無い既存画像は現スキーマにフォールバック（差分判定は不能なので schema_changed=False）。
+            snapshot_fields = image_data.get("extracted_fields")
+            if snapshot_fields is not None:
+                snapshot_fields = decimal_to_float(snapshot_fields)
+                display_fields = snapshot_fields
+                schema_changed = snapshot_fields != current_fields
+            else:
+                display_fields = current_fields
+                schema_changed = False
 
             extracted_info = image_data.get("extracted_info", {})
             extraction_mapping = image_data.get("extraction_mapping", {})
@@ -313,7 +326,8 @@ class ExtractionService:
                 "status": status,
                 "app_name": app_name,
                 "app_display_name": app_display_name,
-                "fields": app_extraction_fields,
+                "fields": display_fields,
+                "schema_changed": schema_changed,
                 "verification_completed": image_data.get("verification_completed", False),
                 "verification_completed_at": image_data.get("verification_completed_at")
             }

--- a/web/src/pages/ocr-result/ExtractedInfoDisplay.tsx
+++ b/web/src/pages/ocr-result/ExtractedInfoDisplay.tsx
@@ -132,7 +132,9 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
   );
 
   const renderStringField = (field: Field) => {
-    const value = editMode ? editedInfo[field.name] : extractedInfo[field.name];
+    const rawValue = editMode ? editedInfo[field.name] : extractedInfo[field.name];
+    // スキーマ変更で旧値が object/array の場合、React child に描画できず落ちるため文字列に丸める
+    const value = (rawValue !== null && typeof rawValue === 'object') ? JSON.stringify(rawValue) : rawValue;
     const suggestion = getSuggestionForField(field.name);
     return (
       <div key={field.name} className="mb-4">
@@ -176,7 +178,9 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
   const renderMapField = (field: Field, parentPath?: string) => {
     if (!field.fields) return null;
     const basePath = parentPath ? `${parentPath}.${field.name}` : field.name;
-    const mapValue = getValueAtPath(basePath) || {};
+    const rawMapValue = getValueAtPath(basePath);
+    // スキーマ変更で旧値が map と合わない（例: 文字列）場合のフォールバック
+    const mapValue = (rawMapValue && typeof rawMapValue === 'object' && !Array.isArray(rawMapValue)) ? rawMapValue : {};
 
     return (
       <div key={field.name} className="mb-6">
@@ -228,7 +232,8 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
   const renderNestedListField = (field: Field, parentPath: string) => {
     if (!field.items) return null;
     const basePath = `${parentPath}.${field.name}`;
-    const listData = getValueAtPath(basePath) || [];
+    const rawListData = getValueAtPath(basePath);
+    const listData: any[] = Array.isArray(rawListData) ? rawListData : [];
 
     return (
       <div key={field.name} className="mb-4">
@@ -259,7 +264,9 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
 
   const renderListField = (field: Field) => {
     if (!field.items) return null;
-    const listData = editMode ? editedInfo[field.name] || [] : extractedInfo[field.name] || [];
+    const rawListData = editMode ? editedInfo[field.name] : extractedInfo[field.name];
+    // スキーマ変更で旧値の型が list と合わない（例: 文字列）場合に .map で落ちるのを防ぐ
+    const listData: any[] = Array.isArray(rawListData) ? rawListData : [];
 
     if (field.items.type === 'map' && field.items.fields) {
       const itemFields = field.items.fields;
@@ -286,7 +293,9 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
                 </tr>
               </thead>
               <tbody className="bg-bg divide-y divide-gray-200">
-                {listData.map((item: any, itemIndex: number) => {
+                {listData.map((rawItem: any, itemIndex: number) => {
+                  // 旧データの行が null/非オブジェクトでもセル参照で落ちないようにする
+                  const item = (rawItem !== null && typeof rawItem === 'object') ? rawItem : {};
                   const rowSuggestions = getSuggestionsForListRow(field.name, itemIndex);
                   const rowKey = `${field.name}[${itemIndex}]`;
                   const isExpanded = expandedSuggestionRow === rowKey;

--- a/web/src/pages/ocr-result/OCRResult.tsx
+++ b/web/src/pages/ocr-result/OCRResult.tsx
@@ -90,6 +90,7 @@ function OcrResult() {
   const extractedInfoSnapshotRef = useRef<Record<string, any>>({});
   const [agentFoundIssues, setAgentFoundIssues] = useState(false);
   const [showReExtractModal, setShowReExtractModal] = useState(false);
+  const [schemaChanged, setSchemaChanged] = useState(false);
   const [showAgentModal, setShowAgentModal] = useState(false);
   const [tools, setTools] = useState<Tool[]>([]);
   const statusCheckTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -364,7 +365,10 @@ function OcrResult() {
 
       // ステータスを明示的に設定
       setExtractionStatus(response.data.status || "pending");
-      
+
+      // 抽出時スキーマと現スキーマの差分（再抽出 warning 用）
+      setSchemaChanged(response.data.schema_changed || false);
+
       // app_nameを設定
       if (response.data.app_name) {
         setAppName(response.data.app_name);
@@ -968,6 +972,7 @@ function OcrResult() {
         appName={appName}
         loading={extractionStatus === 'processing'}
         ocrEnabled={isOcrEnabled()}
+        schemaChanged={schemaChanged}
         onViewOcr={() => changeView("ocr")}
       />
 

--- a/web/src/pages/ocr-result/ReExtractModal.tsx
+++ b/web/src/pages/ocr-result/ReExtractModal.tsx
@@ -11,9 +11,10 @@ interface Props {
   loading?: boolean;
   onViewOcr?: () => void;
   ocrEnabled?: boolean;
+  schemaChanged?: boolean;
 }
 
-export default function ReExtractModal({ isOpen, onClose, onExecute, appName, loading, onViewOcr, ocrEnabled }: Props) {
+export default function ReExtractModal({ isOpen, onClose, onExecute, appName, loading, onViewOcr, ocrEnabled, schemaChanged }: Props) {
   const [showPrompt, setShowPrompt] = useState(false);
   const [customPrompt, setCustomPrompt] = useState('');
   const [originalPrompt, setOriginalPrompt] = useState('');
@@ -76,6 +77,12 @@ export default function ReExtractModal({ isOpen, onClose, onExecute, appName, lo
       <p className="text-sm text-muted mb-4">
         情報抽出を最初からやり直します。現在の抽出結果は上書きされます。
       </p>
+
+      {schemaChanged && (
+        <Alert type="warning" className="mb-4">
+          抽出時からスキーマが更新されています。再抽出すると新しいスキーマで上書きされます。
+        </Alert>
+      )}
 
       {/* カスタムプロンプト展開 */}
       <button

--- a/web/src/types/extraction.ts
+++ b/web/src/types/extraction.ts
@@ -7,6 +7,7 @@ export interface ExtractionResponse {
   app_name: string;
   app_display_name: string;
   fields: Field[];
+  schema_changed?: boolean;
   verification_completed?: boolean;
   verification_completed_at?: string;
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

## Snapshot the extraction schema per image

Extracted results stored only the values (`extracted_info` / `extraction_mapping`),
not the schema (fields) they were extracted against. Display always fetched the
app's CURRENT schema, and app schemas are overwritten in place with no history.
So after editing a usecase's schema and reopening a past image, the frontend
rendered old values against the new schema — a field type change (e.g. string →
list, or a removed table column) threw during render and, with no error boundary,
white-screened the whole result page.

Changes:

- On successful extraction, snapshot the fields onto the image record
  (`extracted_fields`). `update_extracted_info` takes an optional `extracted_fields`
  and only writes it when provided, so manual edit-saves never wipe the snapshot.
- `GET /images/{id}/extraction` returns the snapshot fields when present (falling
  back to the current schema for legacy images), and a `schema_changed` flag when
  the snapshot differs from the current schema (both normalized the same way before
  comparison).
- The re-extract modal shows a warning when `schema_changed` is true; re-extraction
  rewrites the snapshot to the current schema and clears the warning.
- Frontend rendering guards (list / nested-list / map / string fields) coerce
  type-mismatched legacy values instead of crashing, so opening a pre-snapshot
  image can no longer white-screen.

Verified end to end on dev: re-extract writes the snapshot; editing the schema then
reopening shows the warning without crashing; re-extraction clears it; the result
renders against the snapshot schema.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.