### PR TITLE
refactor: centralize status constants and validate status writes

### DIFF
--- a/lambda/api/app/domains/__init__.py
+++ b/lambda/api/app/domains/__init__.py
@@ -21,6 +21,13 @@ from .schema_fields import (
 )
 from .image_status import (
     determine_parent_status,
+    determine_parent_agent_status,
+    ImageStatus,
+    AgentStatus,
+    PageProcessingMode,
+    validate_image_status,
+    validate_agent_status,
+    validate_page_processing_mode,
 )
 from .prompts import (
     create_single_with_ocr_prompt,
@@ -51,6 +58,13 @@ __all__ = [
     "extract_field_names",
     # Image status
     "determine_parent_status",
+    "determine_parent_agent_status",
+    "ImageStatus",
+    "AgentStatus",
+    "PageProcessingMode",
+    "validate_image_status",
+    "validate_agent_status",
+    "validate_page_processing_mode",
     # Prompts
     "create_single_with_ocr_prompt",
     "create_single_without_ocr_prompt",

--- a/lambda/api/app/domains/image_status.py
+++ b/lambda/api/app/domains/image_status.py
@@ -1,7 +1,56 @@
 """画像ステータス判定のドメインロジック"""
 
+
+class ImageStatus:
+    """画像の処理ステータス値。DynamoDB に生文字列で保存される。"""
+    UPLOADING = "uploading"
+    PENDING = "pending"
+    CONVERTING = "converting"
+    OCR = "ocr"
+    EXTRACTING = "extracting"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    ALL = {UPLOADING, PENDING, CONVERTING, OCR, EXTRACTING, PROCESSING, COMPLETED, FAILED}
+
+
+class AgentStatus:
+    """エージェント検証のステータス値。"""
+    IDLE = "idle"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+    ALL = {IDLE, PROCESSING, COMPLETED, FAILED, SKIPPED}
+
+
+class PageProcessingMode:
+    """複数ページ PDF の処理モード。"""
+    COMBINED = "combined"
+    INDIVIDUAL = "individual"
+    ALL = {COMBINED, INDIVIDUAL}
+
+
 # 処理中を表す status（OCR中・抽出中・汎用 processing）。親集約でまとめて扱う。
-_PARENT_PROCESSING_STATUSES = {"ocr", "extracting", "processing"}
+_PARENT_PROCESSING_STATUSES = {ImageStatus.OCR, ImageStatus.EXTRACTING, ImageStatus.PROCESSING}
+
+
+def validate_image_status(status: str) -> None:
+    """無効な画像ステータス値なら ValueError（write 前の検証用）。"""
+    if status not in ImageStatus.ALL:
+        raise ValueError(f"Invalid image status: {status!r}")
+
+
+def validate_agent_status(status: str) -> None:
+    """無効な agent_status 値なら ValueError。"""
+    if status not in AgentStatus.ALL:
+        raise ValueError(f"Invalid agent status: {status!r}")
+
+
+def validate_page_processing_mode(mode: str) -> None:
+    """無効な page_processing_mode 値なら ValueError。"""
+    if mode not in PageProcessingMode.ALL:
+        raise ValueError(f"Invalid page_processing_mode: {mode!r}")
 
 
 def determine_parent_status(children: list[dict]) -> str:
@@ -14,18 +63,18 @@ def determine_parent_status(children: list[dict]) -> str:
         親ドキュメントのステータス
     """
     if not children:
-        return "converting"
+        return ImageStatus.CONVERTING
 
     statuses = [child.get("status") for child in children]
 
-    if all(status == "completed" for status in statuses):
-        return "completed"
-    elif any(status == "failed" for status in statuses):
-        return "failed"
+    if all(status == ImageStatus.COMPLETED for status in statuses):
+        return ImageStatus.COMPLETED
+    elif any(status == ImageStatus.FAILED for status in statuses):
+        return ImageStatus.FAILED
     elif any(status in _PARENT_PROCESSING_STATUSES for status in statuses):
-        return "processing"
+        return ImageStatus.PROCESSING
     else:
-        return "converting"
+        return ImageStatus.CONVERTING
 
 
 def determine_parent_agent_status(children: list[dict]) -> str:
@@ -34,18 +83,18 @@ def determine_parent_agent_status(children: list[dict]) -> str:
     優先度: failed > processing > idle(未実行あり) > completed > skipped
     """
     if not children:
-        return "idle"
+        return AgentStatus.IDLE
 
-    statuses = [child.get("agent_status") or "idle" for child in children]
+    statuses = [child.get("agent_status") or AgentStatus.IDLE for child in children]
 
-    if any(s == "failed" for s in statuses):
-        return "failed"
-    if any(s == "processing" for s in statuses):
-        return "processing"
-    if any(s == "idle" for s in statuses):
-        return "processing"
-    if all(s == "completed" for s in statuses):
-        return "completed"
-    if all(s == "skipped" for s in statuses):
-        return "skipped"
-    return "completed"
+    if any(s == AgentStatus.FAILED for s in statuses):
+        return AgentStatus.FAILED
+    if any(s == AgentStatus.PROCESSING for s in statuses):
+        return AgentStatus.PROCESSING
+    if any(s == AgentStatus.IDLE for s in statuses):
+        return AgentStatus.PROCESSING
+    if all(s == AgentStatus.COMPLETED for s in statuses):
+        return AgentStatus.COMPLETED
+    if all(s == AgentStatus.SKIPPED for s in statuses):
+        return AgentStatus.SKIPPED
+    return AgentStatus.COMPLETED

--- a/lambda/api/app/repositories/image_repository.py
+++ b/lambda/api/app/repositories/image_repository.py
@@ -5,6 +5,10 @@ from botocore.exceptions import ClientError
 from datetime import datetime
 import uuid
 from config import settings
+from domains.image_status import (
+    ImageStatus, PageProcessingMode,
+    validate_image_status, validate_agent_status, validate_page_processing_mode,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -24,8 +28,8 @@ def get_images_table():
     return dynamodb_resource.Table(table_name)
 
 
-def create_image_record(image_id, filename, s3_key, app_name="default", status="pending", converted_s3_key=None,
-                        page_processing_mode="combined", total_pages=None, page_number=None, parent_document_id=None,
+def create_image_record(image_id, filename, s3_key, app_name="default", status=ImageStatus.PENDING, converted_s3_key=None,
+                        page_processing_mode=PageProcessingMode.COMBINED, total_pages=None, page_number=None, parent_document_id=None,
                         sync_source_path=None, uploaded_by=None):
     """
     画像レコードを作成する
@@ -47,6 +51,9 @@ def create_image_record(image_id, filename, s3_key, app_name="default", status="
     Returns:
         str: 作成された画像のID
     """
+    validate_image_status(status)
+    validate_page_processing_mode(page_processing_mode)
+
     if not image_id:
         image_id = str(uuid.uuid4())
 
@@ -211,6 +218,7 @@ def update_image_status(image_id, status, job_id=None):
         status (str): 新しいステータス
         job_id (str, optional): ジョブID
     """
+    validate_image_status(status)
     table = get_images_table()
 
     update_expression = "SET #status = :status"
@@ -339,6 +347,7 @@ def update_converted_image(image_id, converted_s3_key, status=None, original_siz
         }
 
         if status:
+            validate_image_status(status)
             update_expression += ", #status = :status"
             expression_values[":status"] = status
 
@@ -357,6 +366,7 @@ def update_converted_image(image_id, converted_s3_key, status=None, original_siz
             }
 
         if page_processing_mode:
+            validate_page_processing_mode(page_processing_mode)
             update_expression += ", page_processing_mode = :page_processing_mode"
             expression_values[":page_processing_mode"] = page_processing_mode
 
@@ -467,6 +477,7 @@ def update_verification_status(image_id: str, verification_completed: bool, veri
 
 def update_agent_status(image_id: str, status: str, suggestions_count: int = None) -> None:
     """agent_status を更新する"""
+    validate_agent_status(status)
     table = get_images_table()
     try:
         if suggestions_count is not None:
@@ -515,9 +526,9 @@ def create_individual_page_record(page_id: str, parent_image_id: str, filename: 
             "s3_key": converted_s3_key,
             "converted_s3_key": converted_s3_key,
             "upload_time": current_time,
-            "status": "pending",
+            "status": ImageStatus.PENDING,
             "app_name": app_name,
-            "page_processing_mode": "individual",
+            "page_processing_mode": PageProcessingMode.INDIVIDUAL,
             "page_number": page_number,
             "total_pages": total_pages,
             "parent_document_id": parent_image_id,
@@ -546,6 +557,7 @@ def update_parent_document_status(parent_id: str, status: str, total_pages: int 
         status (str): 新しいステータス
         total_pages (int, optional): 総ページ数
     """
+    validate_image_status(status)
     table = get_images_table()
 
     try:

--- a/lambda/api/app/repositories/job_repository.py
+++ b/lambda/api/app/repositories/job_repository.py
@@ -9,6 +9,21 @@ from config import settings
 logger = logging.getLogger(__name__)
 
 
+class JobStatus:
+    """ジョブ（agent 検証 / スキーマ生成）のステータス値。"""
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+    ALL = {PROCESSING, COMPLETED, FAILED, SKIPPED}
+
+
+def validate_job_status(status: str) -> None:
+    """無効なジョブステータス値なら ValueError。"""
+    if status not in JobStatus.ALL:
+        raise ValueError(f"Invalid job status: {status!r}")
+
+
 def get_jobs_table():
     """ジョブテーブルのリソースを取得する"""
     table_name = settings.JOBS_TABLE_NAME
@@ -75,7 +90,7 @@ def create_agent_job(image_id: str):
             "id": job_id,
             "image_id": image_id,
             "job_type": "agent_correction",
-            "status": "processing",
+            "status": JobStatus.PROCESSING,
             "created_at": current_time,
             "updated_at": current_time
         }
@@ -142,6 +157,7 @@ def update_agent_job(job_id: str, status: str, suggestions: list = None, error: 
         suggestions: Correction suggestions
         error: Error message if failed
     """
+    validate_job_status(status)
     table = get_jobs_table()
     current_time = datetime.now().isoformat()
 
@@ -201,7 +217,7 @@ def create_schema_generation_job(s3_key: str, filename: str, instructions: str =
         item = {
             "id": job_id,
             "job_type": "schema_generation",
-            "status": "processing",
+            "status": JobStatus.PROCESSING,
             "created_at": current_time,
             "updated_at": current_time,
             "input": {
@@ -226,6 +242,7 @@ def update_schema_generation_job(job_id: str, status: str, result: dict = None, 
         result: Generated schema dict (e.g. {"fields": [...]})
         error: Error message if failed
     """
+    validate_job_status(status)
     table = get_jobs_table()
     current_time = datetime.now().isoformat()
 

--- a/lambda/api/app/schemas/image_operations.py
+++ b/lambda/api/app/schemas/image_operations.py
@@ -20,4 +20,4 @@ class S3ImportRequest(BaseModel):
     bucket: str
     key: str
     filename: str
-    page_processing_mode: str = "combined"
+    page_processing_mode: Literal["combined", "individual"] = "combined"

--- a/lambda/api/app/schemas/upload.py
+++ b/lambda/api/app/schemas/upload.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+from typing import Literal
 
 
 class PresignedUrlRequest(BaseModel):
@@ -6,7 +7,7 @@ class PresignedUrlRequest(BaseModel):
     filename: str
     content_type: str
     app_name: str = "default"
-    page_processing_mode: str = "combined"
+    page_processing_mode: Literal["combined", "individual"] = "combined"
 
 
 class PresignedUrlResponse(BaseModel):
@@ -21,4 +22,4 @@ class UploadCompleteRequest(BaseModel):
     filename: str
     s3_key: str
     app_name: str = "default"
-    page_processing_mode: str = "combined"
+    page_processing_mode: Literal["combined", "individual"] = "combined"

--- a/lambda/api/app/services/agent_service.py
+++ b/lambda/api/app/services/agent_service.py
@@ -3,6 +3,8 @@
 import base64
 import json
 import logging
+from domains.image_status import AgentStatus
+from repositories.job_repository import JobStatus
 from typing import Dict, Any
 
 import boto3
@@ -36,7 +38,7 @@ class AgentService:
             job_id = create_agent_job(image_id)
             logger.info(f"Created agent job: {job_id} for image: {image_id}")
 
-            update_agent_status(image_id, "processing", suggestions_count=0)
+            update_agent_status(image_id, AgentStatus.PROCESSING, suggestions_count=0)
 
             # Invoke AgentKick Lambda asynchronously
             lambda_client = boto3.client("lambda")
@@ -71,7 +73,7 @@ class AgentService:
             extracted_info = image_data.get("extracted_info", {})
             if not extracted_info:
                 logger.warning(f"No extracted info found for image: {image_id}")
-                update_agent_job(job_id, "completed", suggestions=[])
+                update_agent_job(job_id, JobStatus.COMPLETED, suggestions=[])
                 return
 
             # Resolve allowed tool names from usecase (app_name → usecase_id → tools)
@@ -83,7 +85,7 @@ class AgentService:
             # Skip agent execution if no tools are configured
             if not allowed_tool_names:
                 logger.info(f"No tools configured for usecase '{app_name}'. Skipping agent.")
-                update_agent_job(job_id, "skipped")
+                update_agent_job(job_id, JobStatus.SKIPPED)
                 return
 
             # Fetch images from S3
@@ -109,12 +111,12 @@ class AgentService:
             suggestions = self._parse_agent_response(response_text)
 
             # Update job as completed
-            update_agent_job(job_id, "completed", suggestions=suggestions)
+            update_agent_job(job_id, JobStatus.COMPLETED, suggestions=suggestions)
             logger.info(f"Agent correction completed for job: {job_id}")
 
         except Exception as e:
             logger.error(f"Error in agent correction job {job_id}: {e}")
-            update_agent_job(job_id, "failed", error=str(e))
+            update_agent_job(job_id, JobStatus.FAILED, error=str(e))
     
     async def get_agent_job_status(self, job_id: str) -> Dict[str, Any]:
         """Get agent correction job status

--- a/lambda/api/app/services/extraction_service.py
+++ b/lambda/api/app/services/extraction_service.py
@@ -13,6 +13,7 @@ from background import BackgroundTaskExtension
 from utils import decimal_to_float
 from utils.bedrock import parse_converse_response, extract_json_from_response
 from domains.schema_fields import extract_field_names
+from domains.image_status import ImageStatus, PageProcessingMode
 from clients import s3_client
 from clients.bedrock import call_bedrock, call_bedrock_with_retry
 from domains.extraction_engine import (
@@ -79,7 +80,7 @@ class InformationExtractor(ABC):
             image_data = get_image(self.image_id)
             if not image_data:
                 logger.error(f"画像 {self.image_id} が見つかりません")
-                update_image_status(self.image_id, "failed")
+                update_image_status(self.image_id, ImageStatus.FAILED)
                 raise ValueError(f"画像 {self.image_id} が見つかりません")
 
             app_name = image_data.get("app_name")
@@ -87,7 +88,7 @@ class InformationExtractor(ABC):
                 logger.error(f"app_name not found for image {self.image_id}")
                 raise ValueError(f"app_name not found for image {self.image_id}")
 
-            update_image_status(self.image_id, "extracting")
+            update_image_status(self.image_id, ImageStatus.EXTRACTING)
 
             app_extraction_fields = get_extraction_fields_for_app(app_name)
             field_names = extract_field_names(app_extraction_fields.get("fields", []))
@@ -126,13 +127,13 @@ class InformationExtractor(ABC):
                 result.get("mapping", {}),
                 extracted_fields=app_extraction_fields.get("fields", [])
             )
-            update_image_status(self.image_id, "completed")
+            update_image_status(self.image_id, ImageStatus.COMPLETED)
 
             logger.info(f"情報抽出完了: {self.image_id}")
 
         except Exception as e:
             logger.error(f"情報抽出エラー ({self.__class__.__name__}): {str(e)}")
-            update_image_status(self.image_id, "failed")
+            update_image_status(self.image_id, ImageStatus.FAILED)
             raise
 
     @abstractmethod
@@ -378,11 +379,11 @@ class ExtractionService:
     def _get_extractor(self, image_id: str, image_data: dict):
         """処理モードに応じた抽出器を返す"""
         page_processing_mode = image_data.get(
-            "page_processing_mode", "combined")
+            "page_processing_mode", PageProcessingMode.COMBINED)
         converted_s3_keys = image_data.get("converted_s3_key")
 
         is_multiimage_combined = (
-            page_processing_mode == "combined" and
+            page_processing_mode == PageProcessingMode.COMBINED and
             isinstance(converted_s3_keys, list) and
             len(converted_s3_keys) > 1
         )

--- a/lambda/api/app/services/image_list_service.py
+++ b/lambda/api/app/services/image_list_service.py
@@ -9,6 +9,7 @@ from utils import decimal_to_float
 from repositories.usecase_repository import get_permitted_app_names
 from repositories import user_repository
 from schemas.image import ImageInfo
+from domains.image_status import PageProcessingMode
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +120,7 @@ class ImageListService:
             total_pages = image.get("total_pages", 0)
 
             is_parent = (not parent_document_id and
-                        page_processing_mode == "individual" and
+                        page_processing_mode == PageProcessingMode.INDIVIDUAL and
                         total_pages > 1)
 
             if is_parent:

--- a/lambda/api/app/services/ocr_service.py
+++ b/lambda/api/app/services/ocr_service.py
@@ -15,6 +15,7 @@ from schemas import OcrResult, OcrResultResponse
 from config import settings
 from clients import s3_client, sagemaker_runtime_client, sfn_client
 from domains.ocr_engine import parse_ocr_response, parse_yomitoku_mp_response
+from domains.image_status import ImageStatus, AgentStatus, PageProcessingMode
 from services.pdf_conversion_service import sync_parent_status
 from utils.helpers import float_to_decimal, compress_image_for_payload
 
@@ -135,13 +136,13 @@ class OcrService:
             if not image_data:
                 raise ValueError(f"Image not found: {image_id}")
 
-            update_image_status(image_id, "ocr")
+            update_image_status(image_id, ImageStatus.OCR)
             sync_parent_status(image_id)
 
-            page_processing_mode = image_data.get("page_processing_mode", "combined")
+            page_processing_mode = image_data.get("page_processing_mode", PageProcessingMode.COMBINED)
             converted_s3_keys = image_data.get("converted_s3_key")
             is_multiimage_combined = (
-                page_processing_mode == "combined"
+                page_processing_mode == PageProcessingMode.COMBINED
                 and isinstance(converted_s3_keys, list)
                 and len(converted_s3_keys) > 1
             )
@@ -160,7 +161,7 @@ class OcrService:
 
         except Exception as e:
             logger.error(f"Error processing OCR for image {image_id}: {str(e)}")
-            update_image_status(image_id, "failed")
+            update_image_status(image_id, ImageStatus.FAILED)
             sync_parent_status(image_id)
             raise
 
@@ -295,7 +296,7 @@ class OcrService:
 
             # pending画像を取得
             images = get_images(app_name)
-            pending_images = [img for img in images if img.get('status') == 'pending']
+            pending_images = [img for img in images if img.get('status') == ImageStatus.PENDING]
 
             logger.info(f"Found {len(pending_images)} pending images for app: {app_name}")
 
@@ -316,7 +317,7 @@ class OcrService:
 
             # ステータスを更新
             for img in pending_images:
-                update_image_status(img['id'], 'processing', job_id)
+                update_image_status(img['id'], ImageStatus.PROCESSING, job_id)
 
             # Step Functions起動
             try:
@@ -331,7 +332,7 @@ class OcrService:
             except Exception as sfn_error:
                 logger.error(f"Step Functions start failed, reverting image statuses: {sfn_error}")
                 for img in pending_images:
-                    update_image_status(img['id'], 'pending')
+                    update_image_status(img['id'], ImageStatus.PENDING)
                 raise
 
             logger.info(f"Started Step Functions execution: {execution_response['executionArn']}")
@@ -357,9 +358,9 @@ class OcrService:
             job_id = str(uuid.uuid4())
 
             # 再処理の起点。抽出フェーズへの遷移は extract() 冒頭が担う。
-            update_image_status(image_id, 'ocr', job_id)
+            update_image_status(image_id, ImageStatus.OCR, job_id)
 
-            update_agent_status(image_id, "processing", suggestions_count=0)
+            update_agent_status(image_id, AgentStatus.PROCESSING, suggestions_count=0)
 
             # Step Functions起動（単一画像）
             execution_response = sfn_client.start_execution(

--- a/lambda/api/app/services/pdf_conversion_service.py
+++ b/lambda/api/app/services/pdf_conversion_service.py
@@ -21,7 +21,7 @@ from repositories import (
     create_individual_page_record, get_app_input_methods,
     get_children_by_parent_id, update_agent_status,
 )
-from domains.image_status import determine_parent_status, determine_parent_agent_status
+from domains.image_status import determine_parent_status, determine_parent_agent_status, ImageStatus, AgentStatus, PageProcessingMode
 from utils.helpers import resize_image
 
 logger = logging.getLogger(__name__)
@@ -39,7 +39,7 @@ def convert_pdf_to_image(image_id: str, s3_key: str):
         if not app_name:
             raise ValueError(f"app_name not found for image {image_id}")
 
-        processing_mode = image_data.get("page_processing_mode", "combined")
+        processing_mode = image_data.get("page_processing_mode", PageProcessingMode.COMBINED)
         input_methods = get_app_input_methods(app_name)
 
         # S3 URIからバケット名を取得
@@ -68,9 +68,9 @@ def convert_pdf_to_image(image_id: str, s3_key: str):
             if not upload_bucket:
                 raise ValueError("BUCKET_NAME environment variable is not set")
 
-            if processing_mode == "combined":
+            if processing_mode == PageProcessingMode.COMBINED:
                 _process_combined_pages(pdf_document, image_id, s3_key, upload_bucket)
-            elif processing_mode == "individual" and pdf_document.page_count == 1:
+            elif processing_mode == PageProcessingMode.INDIVIDUAL and pdf_document.page_count == 1:
                 _process_combined_pages(pdf_document, image_id, s3_key, upload_bucket)
             else:
                 _process_individual_pages(pdf_document, image_id, s3_key, upload_bucket)
@@ -84,7 +84,7 @@ def convert_pdf_to_image(image_id: str, s3_key: str):
 
     except Exception as e:
         logger.error(f"PDF変換エラー: {str(e)}")
-        update_image_status(image_id, "failed")
+        update_image_status(image_id, ImageStatus.FAILED)
         try:
             update_ocr_result(image_id, {"error": str(e), "timestamp": datetime.now().isoformat()})
         except Exception as db_error:
@@ -138,7 +138,7 @@ def _process_combined_pages(pdf_document, image_id: str, s3_key: str, upload_buc
         page_s3_keys.append(page_s3_key)
         logger.info(f"ページ {page_num + 1}/{total_pages} 保存完了: {page_s3_key}")
 
-    update_converted_image(image_id, page_s3_keys, "pending", None, None, page_processing_mode="combined", total_pages=total_pages)
+    update_converted_image(image_id, page_s3_keys, ImageStatus.PENDING, None, None, page_processing_mode=PageProcessingMode.COMBINED, total_pages=total_pages)
     logger.info(f"複数画像処理完了: {image_id}, {total_pages}ページ")
 
 
@@ -149,7 +149,7 @@ def _process_single_page_combined(pdf_document, image_id: str, s3_key: str, uplo
     filename_base = os.path.splitext(os.path.basename(s3_key))[0]
     converted_s3_key = f"converted/{datetime.now().isoformat()}_{filename_base}_single.jpeg"
     s3_client.put_object(Bucket=upload_bucket, Key=converted_s3_key, Body=img_data, ContentType="image/jpeg")
-    update_converted_image(image_id, [converted_s3_key], "pending", orig_size, new_size, page_processing_mode="combined", total_pages=1)
+    update_converted_image(image_id, [converted_s3_key], ImageStatus.PENDING, orig_size, new_size, page_processing_mode=PageProcessingMode.COMBINED, total_pages=1)
     logger.info(f"単一ページ処理完了: {image_id}")
 
 
@@ -157,7 +157,7 @@ def _process_individual_pages(pdf_document, parent_image_id: str, s3_key: str, u
     """複数ページPDFを個別ページとして処理する"""
     total_pages = pdf_document.page_count
     logger.info(f"個別処理を開始: {total_pages}ページ")
-    update_parent_document_status(parent_image_id, "converting", total_pages=total_pages)
+    update_parent_document_status(parent_image_id, ImageStatus.CONVERTING, total_pages=total_pages)
 
     created_page_ids = []
     for page_num in range(total_pages):
@@ -170,9 +170,9 @@ def _process_individual_pages(pdf_document, parent_image_id: str, s3_key: str, u
             continue
 
     if created_page_ids:
-        update_parent_document_status(parent_image_id, "pending")
+        update_parent_document_status(parent_image_id, ImageStatus.PENDING)
     else:
-        update_parent_document_status(parent_image_id, "failed")
+        update_parent_document_status(parent_image_id, ImageStatus.FAILED)
         logger.error("個別処理失敗: ページが作成されませんでした")
 
 
@@ -234,7 +234,7 @@ def sync_parent_agent_status(image_id: str) -> None:
         new_agent_status = determine_parent_agent_status(children)
 
         parent_data = get_image(parent_id)
-        current_agent_status = parent_data.get("agent_status") or "idle" if parent_data else "idle"
+        current_agent_status = parent_data.get("agent_status") or AgentStatus.IDLE if parent_data else AgentStatus.IDLE
         if current_agent_status != new_agent_status:
             update_agent_status(parent_id, new_agent_status)
             logger.info(f"親ドキュメント agent_status 更新: {parent_id} -> {new_agent_status}")

--- a/lambda/api/app/services/s3_sync_service.py
+++ b/lambda/api/app/services/s3_sync_service.py
@@ -6,6 +6,7 @@ from typing import Dict, Any, Optional, List
 from botocore.exceptions import ClientError
 
 from config import settings
+from domains.image_status import ImageStatus, PageProcessingMode
 from repositories.schema_repository import get_app_schema
 from repositories.image_repository import create_image_record, get_images_by_sync_source, get_existing_sync_sources
 from schemas import UploadCompleteRequest
@@ -77,7 +78,7 @@ class S3SyncService:
             source_bucket = file_data.get("bucket")
             source_key = file_data.get("key")
             filename = file_data.get("filename")
-            page_processing_mode = file_data.get("page_processing_mode", "combined")
+            page_processing_mode = file_data.get("page_processing_mode", PageProcessingMode.COMBINED)
 
             if not all([source_bucket, source_key, filename]):
                 raise ValueError("bucket, key, filename are required")
@@ -105,7 +106,7 @@ class S3SyncService:
                 filename=filename,
                 s3_key=destination_key,
                 app_name=app_name,
-                status="uploading",
+                status=ImageStatus.UPLOADING,
                 page_processing_mode=page_processing_mode,
                 sync_source_path=source_key,
                 uploaded_by=uploaded_by

--- a/lambda/api/app/services/upload_service.py
+++ b/lambda/api/app/services/upload_service.py
@@ -11,6 +11,7 @@ from schemas import (
     PresignedUrlRequest, PresignedUrlResponse, UploadCompleteRequest
 )
 from config import settings
+from domains.image_status import ImageStatus
 from utils import resize_image
 from repositories import get_app_schemas, get_app_input_methods
 from background import BackgroundTaskExtension
@@ -70,7 +71,7 @@ class UploadService:
                 filename=request.filename,
                 s3_key=s3_key,
                 app_name=request.app_name,
-                status="uploading",
+                status=ImageStatus.UPLOADING,
                 page_processing_mode=request.page_processing_mode,
                 uploaded_by=uploaded_by
             )
@@ -116,7 +117,7 @@ class UploadService:
                 return await self._handle_pdf_conversion(image_id, request)
             else:
                 # 画像ファイルの場合はそのまま処理待ちに
-                update_image_status(image_id, "pending")
+                update_image_status(image_id, ImageStatus.PENDING)
                 return {
                     "status": "success",
                     "message": "Upload completed successfully",
@@ -158,7 +159,7 @@ class UploadService:
                     update_converted_image(
                         image_id,
                         converted_s3_key,
-                        "pending",
+                        ImageStatus.PENDING,
                         orig_size,
                         new_size
                     )
@@ -168,7 +169,7 @@ class UploadService:
                     update_converted_image(
                         image_id,
                         request.s3_key,
-                        "pending",
+                        ImageStatus.PENDING,
                         orig_size,
                         orig_size
                     )
@@ -182,7 +183,7 @@ class UploadService:
         """PDF変換処理"""
         try:
             # ステータスを変換中に更新
-            update_image_status(image_id, "converting")
+            update_image_status(image_id, ImageStatus.CONVERTING)
 
             # バックグラウンドタスクとして変換処理を実行
             if not self.background_task:

--- a/lambda/api/app/tests/domains/test_image_status.py
+++ b/lambda/api/app/tests/domains/test_image_status.py
@@ -5,7 +5,43 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
 
 import pytest
 
-from domains.image_status import determine_parent_status
+from domains.image_status import (
+    determine_parent_status,
+    ImageStatus, AgentStatus, PageProcessingMode,
+    validate_image_status, validate_agent_status, validate_page_processing_mode,
+)
+
+
+class TestStatusValidators:
+    def test_valid_image_status_passes(self):
+        for s in ImageStatus.ALL:
+            validate_image_status(s)  # 例外が出ないこと
+
+    def test_invalid_image_status_raises(self):
+        with pytest.raises(ValueError):
+            validate_image_status("noge")
+
+    def test_not_started_is_not_a_valid_image_status(self):
+        # "not_started" は read 時のデフォルト表示値であり write 値ではない
+        assert "not_started" not in ImageStatus.ALL
+        with pytest.raises(ValueError):
+            validate_image_status("not_started")
+
+    def test_valid_agent_status_passes(self):
+        for s in AgentStatus.ALL:
+            validate_agent_status(s)
+
+    def test_invalid_agent_status_raises(self):
+        with pytest.raises(ValueError):
+            validate_agent_status("bogus")
+
+    def test_valid_page_processing_mode_passes(self):
+        for m in PageProcessingMode.ALL:
+            validate_page_processing_mode(m)
+
+    def test_invalid_page_processing_mode_raises(self):
+        with pytest.raises(ValueError):
+            validate_page_processing_mode("batch")
 
 
 class TestDetermineParentStatus:

--- a/lambda/api/app/tests/domains/test_image_status.py
+++ b/lambda/api/app/tests/domains/test_image_status.py
@@ -19,7 +19,7 @@ class TestStatusValidators:
 
     def test_invalid_image_status_raises(self):
         with pytest.raises(ValueError):
-            validate_image_status("noge")
+            validate_image_status("hoge")
 
     def test_not_started_is_not_a_valid_image_status(self):
         # "not_started" は read 時のデフォルト表示値であり write 値ではない

--- a/lambda/api/app/workers/agent_kick.py
+++ b/lambda/api/app/workers/agent_kick.py
@@ -15,6 +15,8 @@ from repositories.job_repository import create_agent_job, update_agent_job, get_
 from repositories.schema_repository import get_app_schema
 from services.agent_service import AgentService
 from services.pdf_conversion_service import sync_parent_agent_status
+from domains.image_status import AgentStatus
+from repositories.job_repository import JobStatus
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +35,7 @@ def _finalize_skipped_job(event: dict):
     if not job_id:
         return
     try:
-        update_agent_job(job_id, "skipped")
+        update_agent_job(job_id, JobStatus.SKIPPED)
     except Exception as e:
         logger.warning(f"Failed to finalize skipped job {job_id}: {e}")
 
@@ -58,7 +60,7 @@ def agent_kick_handler(event, context):
 
     app_name = image_data.get("app_name", "")
     if not app_name:
-        _update_agent_status(image_id, "skipped")
+        _update_agent_status(image_id, AgentStatus.SKIPPED)
         _finalize_skipped_job(event)
         sync_parent_agent_status(image_id)
         return {"status": "skipped", "reason": "no app_name"}
@@ -67,7 +69,7 @@ def agent_kick_handler(event, context):
     schema = get_app_schema(app_name)
     if not schema or not schema.get("agent_enabled", False):
         logger.info(f"Agent not enabled for app: {app_name}")
-        _update_agent_status(image_id, "skipped")
+        _update_agent_status(image_id, AgentStatus.SKIPPED)
         _finalize_skipped_job(event)
         sync_parent_agent_status(image_id)
         return {"status": "skipped", "reason": "agent_enabled=false"}
@@ -76,29 +78,29 @@ def agent_kick_handler(event, context):
     try:
         if not job_id:
             job_id = create_agent_job(image_id)
-        _update_agent_status(image_id, "processing")
+        _update_agent_status(image_id, AgentStatus.PROCESSING)
         sync_parent_agent_status(image_id)
         agent_service = AgentService()
         asyncio.run(agent_service._process_agent_correction_async(job_id, image_id))
         # Re-read job to check actual status (may be failed internally)
         job = get_job(job_id)
         job_status = job.get("status", "failed") if job else "failed"
-        if job_status == "completed":
+        if job_status == JobStatus.COMPLETED:
             suggestions_count = len(job.get("suggestions", [])) if job else 0
-            update_agent_status(image_id, "completed", suggestions_count=suggestions_count)
+            update_agent_status(image_id, AgentStatus.COMPLETED, suggestions_count=suggestions_count)
             sync_parent_agent_status(image_id)
             return {"image_id": image_id, "status": "completed", "job_id": job_id}
         else:
-            _update_agent_status(image_id, "failed")
+            _update_agent_status(image_id, AgentStatus.FAILED)
             sync_parent_agent_status(image_id)
             return {"image_id": image_id, "status": "failed", "job_id": job_id}
     except Exception as e:
         logger.error(f"Agent invocation failed: {e}")
-        _update_agent_status(image_id, "failed")
+        _update_agent_status(image_id, AgentStatus.FAILED)
         sync_parent_agent_status(image_id)
         if job_id:
             try:
-                update_agent_job(job_id, "failed", error=str(e))
+                update_agent_job(job_id, JobStatus.FAILED, error=str(e))
             except Exception:
                 pass
         return {"image_id": image_id, "status": "failed", "error": str(e)}

--- a/lambda/api/app/workers/schema_generate.py
+++ b/lambda/api/app/workers/schema_generate.py
@@ -15,7 +15,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from repositories.job_repository import update_schema_generation_job
+from repositories.job_repository import update_schema_generation_job, JobStatus
 from schemas import SchemaGenerateRequest
 from services.schema_service import SchemaService
 
@@ -44,7 +44,7 @@ def schema_generate_handler(event, context):
         error_msg = "s3_key or filename is missing in event"
         logger.error(f"schema_generate_handler: {error_msg}")
         try:
-            update_schema_generation_job(job_id, "failed", error=error_msg)
+            update_schema_generation_job(job_id, JobStatus.FAILED, error=error_msg)
         except Exception as e:
             logger.warning(f"Failed to update job {job_id}: {e}")
         return {"job_id": job_id, "status": "failed"}
@@ -60,13 +60,13 @@ def schema_generate_handler(event, context):
         # 既存の generate_schema (async) を同期的に実行
         schema = asyncio.run(service.generate_schema(request))
 
-        update_schema_generation_job(job_id, "completed", result=schema)
+        update_schema_generation_job(job_id, JobStatus.COMPLETED, result=schema)
         logger.info(f"Schema generation job {job_id} completed")
         return {"job_id": job_id, "status": "completed"}
     except Exception as e:
         logger.error(f"Schema generation job {job_id} failed: {e}")
         try:
-            update_schema_generation_job(job_id, "failed", error=str(e))
+            update_schema_generation_job(job_id, JobStatus.FAILED, error=str(e))
         except Exception as update_err:
             logger.error(f"Failed to update failed job {job_id}: {update_err}")
         return {"job_id": job_id, "status": "failed", "error": str(e)}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

## Centralize status constants and validate status writes

Status-like enums (image status, agent status, job status, page_processing_mode)
were bare string literals scattered across ~15 files with no central definition
and no validation. A call like `update_image_status(id, "hoge")` silently
persisted an invalid value to DynamoDB, which then broke the UI inconsistently
(unknown badge, mis-shown "completed", non-terminating polling). Roles/permissions
were already centralized (`_ROLE_RANK`/`_LEVEL_RANK`); status was the gap.

Changes:

- Add plain string-constant classes with an `ALL` set: `ImageStatus`,
  `AgentStatus`, `PageProcessingMode` (domains/image_status.py) and `JobStatus`
  (repositories/job_repository.py). Plain constants (not `enum.Enum`) to match
  the codebase's existing Literal+constant style.
- Validate at DB write boundaries: `update_image_status`, `create_image_record`,
  `update_parent_document_status`, `update_agent_status`, `update_agent_job`,
  `update_schema_generation_job`, and `update_converted_image` (only when a
  status/mode is actually written) now raise `ValueError` on an out-of-set value,
  so invalid values fail fast instead of corrupting the DB.
- Replace scattered status/mode string literals with constant references
  (values unchanged — behavior-preserving). Worker return payloads are left
  as-is (they are response contracts, not DB status writes).
- Constrain `page_processing_mode` to `Literal["combined","individual"]` in the
  three request schemas (PresignedUrlRequest, UploadCompleteRequest,
  S3ImportRequest).

Verified on dev: normal flow (re-extraction reaches `completed`) unchanged;
an invalid `page_processing_mode` is rejected with HTTP 422; unit tests cover the
validators and the existing parent-aggregation behavior is preserved.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.