### PR TITLE
refactor: convert status/type constants to StrEnum and type schema fields with pydantic

### DIFF
--- a/.kiro/steering/coding-rules.md
+++ b/.kiro/steering/coding-rules.md
@@ -15,13 +15,19 @@ inclusion: always
 - **スキーマは schemas/ に集約**: Pydantic モデルを router 内にインライン定義しない。
 - **import はモジュール先頭**: 循環参照を避ける場合を除き、関数内での遅延 import は禁止。
 - **変更後は pyflakes 実行**: 変更したファイルに対して `python -m pyflakes` を実行し、未使用 import や構文エラーがないことを確認する。
+- **enum 的な値は `StrEnum` にする**: status / mode / type など取りうる値が決まった文字列は、リテラルを散在させず `StrEnum` に集約し、write 前に検証する（`XxxStatus(value)` が無効値で ValueError）。
 
 ## フロントエンド (React TypeScript)
 
 - **関数コンポーネント + Hooks パターンを使用**: class component は使わない。
 - **型は camelCase 統一**: API レスポンスの snake_case はサービス層で変換。
 - **巨大コンポーネントは分割**: 複雑なステート管理・ポーリングはカスタムフックに切り出す。
+- **enum 的な値は union 型で締める**: status / type 等は `string` でなく取りうる値の union にする。
 
 ## CDK (TypeScript)
 
 - **Construct パターンで機能単位に分割**: 認証・DB・API・OCR エンドポイント等を個別 Construct として切り出す。
+
+## コメント（共通）
+
+- **コメントは WHY を書く**: 何をするか（HOW/WHAT）の逐語説明でなく、なぜそうするかを書く。変更履歴・before/after は書かない（公開リポジトリ）。

--- a/lambda/api/app/domains/image_status.py
+++ b/lambda/api/app/domains/image_status.py
@@ -1,7 +1,9 @@
 """画像ステータス判定のドメインロジック"""
 
+from enum import StrEnum
 
-class ImageStatus:
+
+class ImageStatus(StrEnum):
     """画像の処理ステータス値。DynamoDB に生文字列で保存される。"""
     UPLOADING = "uploading"
     PENDING = "pending"
@@ -11,24 +13,21 @@ class ImageStatus:
     PROCESSING = "processing"
     COMPLETED = "completed"
     FAILED = "failed"
-    ALL = {UPLOADING, PENDING, CONVERTING, OCR, EXTRACTING, PROCESSING, COMPLETED, FAILED}
 
 
-class AgentStatus:
+class AgentStatus(StrEnum):
     """エージェント検証のステータス値。"""
     IDLE = "idle"
     PROCESSING = "processing"
     COMPLETED = "completed"
     FAILED = "failed"
     SKIPPED = "skipped"
-    ALL = {IDLE, PROCESSING, COMPLETED, FAILED, SKIPPED}
 
 
-class PageProcessingMode:
+class PageProcessingMode(StrEnum):
     """複数ページ PDF の処理モード。"""
     COMBINED = "combined"
     INDIVIDUAL = "individual"
-    ALL = {COMBINED, INDIVIDUAL}
 
 
 # 処理中を表す status（OCR中・抽出中・汎用 processing）。親集約でまとめて扱う。
@@ -37,20 +36,17 @@ _PARENT_PROCESSING_STATUSES = {ImageStatus.OCR, ImageStatus.EXTRACTING, ImageSta
 
 def validate_image_status(status: str) -> None:
     """無効な画像ステータス値なら ValueError（write 前の検証用）。"""
-    if status not in ImageStatus.ALL:
-        raise ValueError(f"Invalid image status: {status!r}")
+    ImageStatus(status)
 
 
 def validate_agent_status(status: str) -> None:
     """無効な agent_status 値なら ValueError。"""
-    if status not in AgentStatus.ALL:
-        raise ValueError(f"Invalid agent status: {status!r}")
+    AgentStatus(status)
 
 
 def validate_page_processing_mode(mode: str) -> None:
     """無効な page_processing_mode 値なら ValueError。"""
-    if mode not in PageProcessingMode.ALL:
-        raise ValueError(f"Invalid page_processing_mode: {mode!r}")
+    PageProcessingMode(mode)
 
 
 def determine_parent_status(children: list[dict]) -> str:

--- a/lambda/api/app/repositories/job_repository.py
+++ b/lambda/api/app/repositories/job_repository.py
@@ -1,5 +1,6 @@
 from clients import dynamodb_resource
 import logging
+from enum import StrEnum
 from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
 from datetime import datetime
@@ -9,19 +10,35 @@ from config import settings
 logger = logging.getLogger(__name__)
 
 
-class JobStatus:
+class JobStatus(StrEnum):
     """ジョブ（agent 検証 / スキーマ生成）のステータス値。"""
     PROCESSING = "processing"
     COMPLETED = "completed"
     FAILED = "failed"
     SKIPPED = "skipped"
-    ALL = {PROCESSING, COMPLETED, FAILED, SKIPPED}
 
 
 def validate_job_status(status: str) -> None:
     """無効なジョブステータス値なら ValueError。"""
-    if status not in JobStatus.ALL:
-        raise ValueError(f"Invalid job status: {status!r}")
+    JobStatus(status)
+
+
+class JobType(StrEnum):
+    """ジョブ種別。"""
+    AGENT_CORRECTION = "agent_correction"
+    SCHEMA_GENERATION = "schema_generation"
+
+
+class SuggestionStatus(StrEnum):
+    """エージェント提案の状態。"""
+    PENDING = "pending"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+
+
+def validate_suggestion_status(status: str) -> None:
+    """無効な提案ステータス値なら ValueError。"""
+    SuggestionStatus(status)
 
 
 def get_jobs_table():
@@ -61,7 +78,7 @@ def get_latest_agent_job_by_image_id(image_id: str) -> dict | None:
         response = table.query(
             IndexName="ImageIdIndex",
             KeyConditionExpression=Key("image_id").eq(image_id),
-            FilterExpression=Attr("job_type").eq("agent_correction"),
+            FilterExpression=Attr("job_type").eq(JobType.AGENT_CORRECTION),
             ScanIndexForward=False,
             Limit=10,
         )
@@ -89,7 +106,7 @@ def create_agent_job(image_id: str):
         item = {
             "id": job_id,
             "image_id": image_id,
-            "job_type": "agent_correction",
+            "job_type": JobType.AGENT_CORRECTION,
             "status": JobStatus.PROCESSING,
             "created_at": current_time,
             "updated_at": current_time
@@ -112,6 +129,7 @@ def update_suggestion_status(image_id: str, suggestion_index: int, status: str) 
     Returns:
         int: Number of remaining pending suggestions
     """
+    validate_suggestion_status(status)
     job = get_latest_agent_job_by_image_id(image_id)
     if not job:
         raise ValueError("No agent job found for this image")
@@ -135,7 +153,7 @@ def update_suggestion_status(image_id: str, suggestion_index: int, status: str) 
 
     # Count pending suggestions (after our update applied locally)
     suggestions[suggestion_index]["status"] = status
-    pending_count = sum(1 for s in suggestions if s.get("status", "pending") == "pending")
+    pending_count = sum(1 for s in suggestions if s.get("status", SuggestionStatus.PENDING) == SuggestionStatus.PENDING)
 
     # Update image record with new pending count
     images_table = get_images_table()
@@ -169,7 +187,7 @@ def update_agent_job(job_id: str, status: str, suggestions: list = None, error: 
             ":updated_at": current_time
         }
 
-        if status == "completed":
+        if status == JobStatus.COMPLETED:
             update_expr += ", completed_at = :completed_at"
             expr_attr_values[":completed_at"] = current_time
 
@@ -216,7 +234,7 @@ def create_schema_generation_job(s3_key: str, filename: str, instructions: str =
     try:
         item = {
             "id": job_id,
-            "job_type": "schema_generation",
+            "job_type": JobType.SCHEMA_GENERATION,
             "status": JobStatus.PROCESSING,
             "created_at": current_time,
             "updated_at": current_time,
@@ -254,7 +272,7 @@ def update_schema_generation_job(job_id: str, status: str, result: dict = None, 
             ":updated_at": current_time,
         }
 
-        if status == "completed":
+        if status == JobStatus.COMPLETED:
             update_expr += ", completed_at = :completed_at"
             expr_attr_values[":completed_at"] = current_time
 

--- a/lambda/api/app/routers/images.py
+++ b/lambda/api/app/routers/images.py
@@ -25,7 +25,7 @@ from dependencies.auth import (
     RequireImagePermission,
 )
 from repositories import get_image
-from repositories.job_repository import get_latest_agent_job_by_image_id, update_suggestion_status
+from repositories.job_repository import get_latest_agent_job_by_image_id, update_suggestion_status, SuggestionStatus
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/images", tags=["Images"])
@@ -294,7 +294,7 @@ async def get_agent_job_by_image(
         suggestions = job.get("suggestions", [])
         pending = []
         for i, s in enumerate(suggestions):
-            if s.get("status", "pending") == "pending":
+            if s.get("status", SuggestionStatus.PENDING) == SuggestionStatus.PENDING:
                 pending.append({**s, "index": i})
         return {
             "job_id": job.get("id"),

--- a/lambda/api/app/schemas/schema.py
+++ b/lambda/api/app/schemas/schema.py
@@ -1,5 +1,25 @@
 from pydantic import BaseModel
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Literal
+
+
+FieldType = Literal["string", "number", "map", "list"]
+
+
+class FieldItems(BaseModel):
+    """list 型フィールドの要素定義"""
+    type: FieldType
+    fields: Optional[List["SchemaField"]] = None  # 要素が map の場合の子フィールド
+    model_config = {"extra": "forbid"}
+
+
+class SchemaField(BaseModel):
+    """抽出スキーマのフィールド定義（再帰構造）"""
+    name: str
+    display_name: str
+    type: FieldType
+    fields: Optional[List["SchemaField"]] = None  # map 型の子フィールド
+    items: Optional[FieldItems] = None            # list 型の要素定義
+    model_config = {"extra": "forbid"}
 
 
 class SchemaGenerateRequest(BaseModel):
@@ -14,7 +34,7 @@ class SchemaSaveRequest(BaseModel):
     name: str
     display_name: str
     description: Optional[str] = None
-    fields: List[Dict[str, Any]]
+    fields: List[SchemaField]
     input_methods: Dict[str, Any]
     agent_enabled: bool = False
     # スキーマ生成に使ったサンプル画像の S3 キー (schema-uploads/ 配下)。

--- a/lambda/api/app/services/agent_service.py
+++ b/lambda/api/app/services/agent_service.py
@@ -4,7 +4,7 @@ import base64
 import json
 import logging
 from domains.image_status import AgentStatus
-from repositories.job_repository import JobStatus
+from repositories.job_repository import JobStatus, SuggestionStatus
 from typing import Dict, Any
 
 import boto3
@@ -134,7 +134,7 @@ class AgentService:
         suggestions = job.get("suggestions", [])
         pending = []
         for i, s in enumerate(suggestions):
-            if s.get("status", "pending") == "pending":
+            if s.get("status", SuggestionStatus.PENDING) == SuggestionStatus.PENDING:
                 pending.append({**s, "index": i})
 
         return {

--- a/lambda/api/app/services/schema_service.py
+++ b/lambda/api/app/services/schema_service.py
@@ -20,6 +20,7 @@ from repositories import (
 from repositories.image_repository import create_s3_sync_folder
 from repositories.usecase_repository import register_usecase_owner, delete_usecase_by_app_name, get_permitted_apps_with_permission
 from repositories.job_repository import (
+    JobType,
     create_schema_generation_job,
     get_job,
 )
@@ -49,7 +50,8 @@ class SchemaService:
             "name": request.name,
             "display_name": request.display_name,
             "description": request.description or f"{request.display_name}からの情報抽出",
-            "fields": request.fields,
+            # SchemaField(pydantic) → dict（既存の保存形と同じ。None キーは落とす）
+            "fields": [f.model_dump(exclude_none=True) for f in request.fields],
             "input_methods": request.input_methods,
             "agent_enabled": request.agent_enabled,
             "sample_image_s3_key": request.sample_image_s3_key,
@@ -384,7 +386,7 @@ class SchemaService:
         if not job:
             raise ValueError(f"Job not found: {job_id}")
 
-        if job.get("job_type") != "schema_generation":
+        if job.get("job_type") != JobType.SCHEMA_GENERATION:
             raise ValueError(f"Job {job_id} is not a schema_generation job")
 
         return {

--- a/lambda/api/app/tests/domains/test_image_status.py
+++ b/lambda/api/app/tests/domains/test_image_status.py
@@ -14,7 +14,7 @@ from domains.image_status import (
 
 class TestStatusValidators:
     def test_valid_image_status_passes(self):
-        for s in ImageStatus.ALL:
+        for s in ImageStatus:
             validate_image_status(s)  # 例外が出ないこと
 
     def test_invalid_image_status_raises(self):
@@ -23,12 +23,12 @@ class TestStatusValidators:
 
     def test_not_started_is_not_a_valid_image_status(self):
         # "not_started" は read 時のデフォルト表示値であり write 値ではない
-        assert "not_started" not in ImageStatus.ALL
+        assert "not_started" not in set(ImageStatus)
         with pytest.raises(ValueError):
             validate_image_status("not_started")
 
     def test_valid_agent_status_passes(self):
-        for s in AgentStatus.ALL:
+        for s in AgentStatus:
             validate_agent_status(s)
 
     def test_invalid_agent_status_raises(self):
@@ -36,7 +36,7 @@ class TestStatusValidators:
             validate_agent_status("bogus")
 
     def test_valid_page_processing_mode_passes(self):
-        for m in PageProcessingMode.ALL:
+        for m in PageProcessingMode:
             validate_page_processing_mode(m)
 
     def test_invalid_page_processing_mode_raises(self):

--- a/lambda/api/app/tests/repositories/test_job_status.py
+++ b/lambda/api/app/tests/repositories/test_job_status.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import pytest
+
+from repositories.job_repository import (
+    SuggestionStatus, validate_suggestion_status,
+    JobStatus, validate_job_status,
+)
+
+
+class TestSuggestionStatus:
+    def test_valid_passes(self):
+        for s in SuggestionStatus:
+            validate_suggestion_status(s)
+
+    def test_invalid_rejected(self):
+        with pytest.raises(ValueError):
+            validate_suggestion_status("bogus")
+
+
+class TestJobStatus:
+    def test_valid_passes(self):
+        for s in JobStatus:
+            validate_job_status(s)
+
+    def test_invalid_rejected(self):
+        with pytest.raises(ValueError):
+            validate_job_status("bogus")

--- a/lambda/api/app/tests/schemas/test_schema_field.py
+++ b/lambda/api/app/tests/schemas/test_schema_field.py
@@ -1,0 +1,35 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import pytest
+from pydantic import ValidationError
+
+from schemas.schema import SchemaField
+
+
+class TestSchemaField:
+    def test_valid_types_pass(self):
+        for t in ("string", "number", "map", "list"):
+            SchemaField(name="f", display_name="F", type=t)
+
+    def test_nested_map_and_list(self):
+        f = SchemaField(
+            name="items", display_name="明細", type="list",
+            items={"type": "map", "fields": [{"name": "d", "display_name": "品目", "type": "string"}]},
+        )
+        assert f.items.fields[0].name == "d"
+
+    def test_invalid_type_rejected(self):
+        with pytest.raises(ValidationError):
+            SchemaField(name="f", display_name="F", type="bogus")
+
+    def test_missing_name_rejected(self):
+        with pytest.raises(ValidationError):
+            SchemaField(display_name="F", type="string")
+
+    def test_extra_key_rejected(self):
+        # 定義外キー（typo・野良キー）は forbid で弾く
+        with pytest.raises(ValidationError):
+            SchemaField(name="f", display_name="F", type="string", feilds=[])

--- a/web/src/pages/schema/SchemaFieldsEditor.tsx
+++ b/web/src/pages/schema/SchemaFieldsEditor.tsx
@@ -11,6 +11,7 @@ import { Field } from "../../types/app-schema";
  */
 
 const FIELD_TYPES = ["string", "number", "map", "list"] as const;
+type FieldType = typeof FIELD_TYPES[number];
 
 const getTypeClass = (type: string) => {
   switch (type) {
@@ -36,7 +37,7 @@ const createNewField = (existing: Field[]): Field => {
 };
 
 /** type 変更時にフィールド構造を整合させる */
-const applyTypeChange = (field: Field, newType: string): Field => {
+const applyTypeChange = (field: Field, newType: FieldType): Field => {
   const base: Field = { name: field.name, display_name: field.display_name, type: newType };
   if (newType === "map") {
     base.fields = field.fields || [];
@@ -70,8 +71,8 @@ const FieldRow: React.FC<FieldRowProps> = ({ field, level, onChange, onRemove })
   };
 
   // list items 用ハンドラ
-  const changeItemsType = (newType: string) => {
-    const items: Field["items"] = { type: newType };
+  const changeItemsType = (newType: FieldType) => {
+    const items: NonNullable<Field["items"]> = { type: newType };
     if (newType === "map") {
       items.fields = field.items?.fields || [];
     }
@@ -116,7 +117,7 @@ const FieldRow: React.FC<FieldRowProps> = ({ field, level, onChange, onRemove })
         />
         <select
           value={field.type}
-          onChange={(e) => onChange(applyTypeChange(field, e.target.value))}
+          onChange={(e) => onChange(applyTypeChange(field, e.target.value as FieldType))}
           className={`border border-default rounded-lg px-2.5 py-1.5 text-xs font-medium focus:outline-none focus:ring-2 focus:ring-primary ${getTypeClass(field.type)}`}
           aria-label="型"
         >
@@ -165,7 +166,7 @@ const FieldRow: React.FC<FieldRowProps> = ({ field, level, onChange, onRemove })
             <span className="text-sm font-medium">リスト項目</span>
             <select
               value={field.items.type}
-              onChange={(e) => changeItemsType(e.target.value)}
+              onChange={(e) => changeItemsType(e.target.value as FieldType)}
               className={`border border-default rounded-lg px-2.5 py-1.5 text-xs font-medium focus:outline-none focus:ring-2 focus:ring-primary ${getTypeClass(field.items.type)}`}
               aria-label="リスト項目の型"
             >

--- a/web/src/types/app-schema.ts
+++ b/web/src/types/app-schema.ts
@@ -1,10 +1,10 @@
 export interface Field {
   name: string;
   display_name: string;
-  type: string;
+  type: 'string' | 'number' | 'map' | 'list';
   fields?: Field[];    // map型のフィールド用
   items?: {           // list型のフィールド用
-    type: string;
+    type: 'string' | 'number' | 'map' | 'list';
     fields?: Field[];
   };
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Follow-up to the earlier status-validation hardening (PR #74). That PR centralized image/agent/job status and page-processing mode into plain string-constant classes with write-time validation. This PR finishes the job for the remaining enum-like values and tightens the loosely-typed schema `fields` structure.

### 1. StrEnum for all enum-like values

The six constant classes (`ImageStatus`, `AgentStatus`, `PageProcessingMode`, `JobStatus`, `JobType`, `SuggestionStatus`) are now `enum.StrEnum` instead of plain classes with an `ALL` set.

- Validation comes for free: `validate_*` now delegates to the enum constructor (`ImageStatus(value)` raises `ValueError` on an invalid value), so the manual `if value not in ALL` checks are gone.
- `JobType` and `SuggestionStatus` are newly centralized and validated (previously hardcoded string literals such as `"agent_correction"` / `"pending"` scattered across the repository and service layers).
- `SuggestionStatus` validation is enforced on write in `update_suggestion_status`.
- Because `StrEnum` members are `str` subclasses, DynamoDB persistence, string comparisons, and JSON serialization are transparent — verified that botocore serializes a member as its plain value (e.g. `"ocr"`, not `"ImageStatus.OCR"`), and that API responses read plain strings back from DynamoDB.

### 2. Typed schema fields with pydantic

`SchemaSaveRequest.fields` was `List[Dict[str, Any]]`, so a malformed field definition (missing `name`/`type`, invalid `type`, stray keys) was stored as-is and could crash extraction/prompt building downstream with a `KeyError`.

- Introduced recursive pydantic models `SchemaField` and `FieldItems` with `model_config = {"extra": "forbid"}` and `type: Literal["string", "number", "map", "list"]`.
- Malformed field definitions are now rejected at the request boundary (422) instead of failing deep in extraction.
- The stored shape is unchanged: `_build_app_data` dumps the models with `model_dump(exclude_none=True)`, producing dicts byte-for-byte identical to the previous format. Confirmed existing app schemas (including `number`-typed fields and nested map/list) still parse and re-save without error.
- The frontend `Field` type union is tightened to match (`'string' | 'number' | 'map' | 'list'`).

Note: proper handling of the `number` field type (the schema-generation prompt currently only teaches the model three types) is intentionally deferred to a separate PR; `number` is kept in the `Literal` here so existing data is not broken.

### Steering

Added a coding rule: enum-like values should be `StrEnum` (constructor validates on write).

### Verification

- Backend: pytest (23 passed, incl. new `SchemaField` and validator tests), pyflakes clean, no circular imports.
- Frontend: `tsc` clean.
- Deployed to a test environment and verified end-to-end via the browser: saving an existing schema (with mixed string/number/map/list fields) returns 200, and rejecting an agent suggestion issues a 200 `PATCH .../agent/suggestions/{index}`. No console errors, no enum-repr leakage.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.