### PR TITLE
feat: add semantic validation for schema fields on save

### DIFF
--- a/lambda/api/app/schemas/__init__.py
+++ b/lambda/api/app/schemas/__init__.py
@@ -8,6 +8,7 @@ from .schema import (
     SchemaSaveRequest,
     SchemaGenerateStartResponse,
     SchemaGenerateStatusResponse,
+    NAME_PATTERN,
 )
 from .job import JobStartResponse
 from .image import ImageInfo
@@ -30,6 +31,7 @@ __all__ = [
     "SchemaSaveRequest",
     "SchemaGenerateStartResponse",
     "SchemaGenerateStatusResponse",
+    "NAME_PATTERN",
     # Job
     "JobStartResponse",
     # Image

--- a/lambda/api/app/schemas/schema.py
+++ b/lambda/api/app/schemas/schema.py
@@ -1,8 +1,23 @@
-from pydantic import BaseModel
+import re
+
+from pydantic import BaseModel, field_validator, model_validator
 from typing import Optional, List, Dict, Any, Literal
 
 
 FieldType = Literal["string", "number", "map", "list"]
+
+# フィールド名 / アプリ名に許可する文字。英数字とアンダースコアのみ。
+# keep in sync: services/schema_service.py（アプリ名検証）, web/src/utils/schemaValidation.ts（NAME_PATTERN）
+NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_]+$")
+
+
+def _validate_sibling_field_names(fields: List["SchemaField"]) -> None:
+    """同じ階層でフィールド名が重複していないか検証する（重複で ValueError）。"""
+    seen = set()
+    for f in fields:
+        if f.name in seen:
+            raise ValueError(f"同じ階層でフィールド名が重複しています: {f.name}")
+        seen.add(f.name)
 
 
 class FieldItems(BaseModel):
@@ -10,6 +25,19 @@ class FieldItems(BaseModel):
     type: FieldType
     fields: Optional[List["SchemaField"]] = None  # 要素が map の場合の子フィールド
     model_config = {"extra": "forbid"}
+
+    @model_validator(mode="after")
+    def _check_structure(self) -> "FieldItems":
+        if self.type == "list":
+            raise ValueError("list の要素として list 型は指定できません")
+        if self.type == "map":
+            if not self.fields:
+                raise ValueError("list の map 要素には子フィールド(fields)が必要です")
+            _validate_sibling_field_names(self.fields)
+        else:  # string / number
+            if self.fields is not None:
+                raise ValueError("list の string / number 要素に fields は指定できません")
+        return self
 
 
 class SchemaField(BaseModel):
@@ -20,6 +48,42 @@ class SchemaField(BaseModel):
     fields: Optional[List["SchemaField"]] = None  # map 型の子フィールド
     items: Optional[FieldItems] = None            # list 型の要素定義
     model_config = {"extra": "forbid"}
+
+    @field_validator("name")
+    @classmethod
+    def _check_name(cls, v: str) -> str:
+        if not v:
+            raise ValueError("フィールド名は必須です")
+        if not NAME_PATTERN.match(v):
+            raise ValueError(f"フィールド名は英数字とアンダースコアのみ使用できます: {v!r}")
+        return v
+
+    @field_validator("display_name")
+    @classmethod
+    def _check_display_name(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("表示名は必須です")
+        return v
+
+    @model_validator(mode="after")
+    def _check_structure(self) -> "SchemaField":
+        # エラーメッセージに display_name を埋め込み、どのフィールドが原因か特定しやすくする
+        label = self.display_name
+        if self.type == "map":
+            if not self.fields:
+                raise ValueError(f"map 型「{label}」には子フィールド(fields)が必要です")
+            if self.items is not None:
+                raise ValueError(f"map 型「{label}」に items は指定できません")
+            _validate_sibling_field_names(self.fields)
+        elif self.type == "list":
+            if self.items is None:
+                raise ValueError(f"list 型「{label}」には要素定義(items)が必要です")
+            if self.fields is not None:
+                raise ValueError(f"list 型「{label}」に fields は指定できません")
+        else:  # string / number
+            if self.fields is not None or self.items is not None:
+                raise ValueError(f"{self.type} 型「{label}」に fields や items は指定できません")
+        return self
 
 
 class SchemaGenerateRequest(BaseModel):
@@ -43,6 +107,14 @@ class SchemaSaveRequest(BaseModel):
     sample_image_filename: Optional[str] = None
     # スキーマ生成に使った指示プロンプト。編集画面で復元し「プロンプトだけ変えて再生成」を可能にする。
     schema_instructions: Optional[str] = None
+
+    @field_validator("fields")
+    @classmethod
+    def _check_fields(cls, v: List[SchemaField]) -> List[SchemaField]:
+        if not v:
+            raise ValueError("スキーマには最低1つのフィールドが必要です")
+        _validate_sibling_field_names(v)
+        return v
 
 
 class SchemaGenerateStartResponse(BaseModel):

--- a/lambda/api/app/schemas/schema.py
+++ b/lambda/api/app/schemas/schema.py
@@ -1,7 +1,7 @@
 import re
 
-from pydantic import BaseModel, field_validator, model_validator
-from typing import Optional, List, Dict, Any, Literal
+from pydantic import BaseModel, StringConstraints, field_validator, model_validator
+from typing import Annotated, Optional, List, Dict, Any, Literal
 
 
 FieldType = Literal["string", "number", "map", "list"]
@@ -9,6 +9,9 @@ FieldType = Literal["string", "number", "map", "list"]
 # フィールド名 / アプリ名に許可する文字。英数字とアンダースコアのみ。
 # keep in sync: services/schema_service.py（アプリ名検証）, web/src/utils/schemaValidation.ts（NAME_PATTERN）
 NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_]+$")
+
+FieldName = Annotated[str, StringConstraints(pattern=NAME_PATTERN.pattern)]
+DisplayName = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 
 
 def _validate_sibling_field_names(fields: List["SchemaField"]) -> None:
@@ -42,28 +45,12 @@ class FieldItems(BaseModel):
 
 class SchemaField(BaseModel):
     """抽出スキーマのフィールド定義（再帰構造）"""
-    name: str
-    display_name: str
+    name: FieldName
+    display_name: DisplayName
     type: FieldType
     fields: Optional[List["SchemaField"]] = None  # map 型の子フィールド
     items: Optional[FieldItems] = None            # list 型の要素定義
     model_config = {"extra": "forbid"}
-
-    @field_validator("name")
-    @classmethod
-    def _check_name(cls, v: str) -> str:
-        if not v:
-            raise ValueError("フィールド名は必須です")
-        if not NAME_PATTERN.match(v):
-            raise ValueError(f"フィールド名は英数字とアンダースコアのみ使用できます: {v!r}")
-        return v
-
-    @field_validator("display_name")
-    @classmethod
-    def _check_display_name(cls, v: str) -> str:
-        if not v or not v.strip():
-            raise ValueError("表示名は必須です")
-        return v
 
     @model_validator(mode="after")
     def _check_structure(self) -> "SchemaField":

--- a/lambda/api/app/services/schema_service.py
+++ b/lambda/api/app/services/schema_service.py
@@ -3,13 +3,13 @@ import boto3
 import json
 import logging
 import os
-import re
 import uuid
 from datetime import datetime
 from typing import Dict, Any
 
 from schemas import (
-    SchemaGenerateRequest, PresignedUrlRequest, CustomPromptRequest, PresignedUrlResponse, SchemaSaveRequest
+    SchemaGenerateRequest, PresignedUrlRequest, CustomPromptRequest, PresignedUrlResponse, SchemaSaveRequest,
+    NAME_PATTERN,
 )
 from config import settings
 from repositories import (
@@ -171,7 +171,7 @@ class SchemaService:
                 raise ValueError("アプリ名と表示名は必須です")
 
             # アプリ名のバリデーション（英数字とアンダースコアのみ）
-            if not re.match(r'^[a-zA-Z0-9_]+$', request.name):
+            if not NAME_PATTERN.match(request.name):
                 raise ValueError("アプリ名は英数字とアンダースコアのみ使用できます")
 
             # 入力方法のバリデーション
@@ -403,7 +403,7 @@ class SchemaService:
                 raise ValueError("アプリ名と表示名は必須です")
 
             # アプリ名のバリデーション（英数字とアンダースコアのみ）
-            if not re.match(r'^[a-zA-Z0-9_]+$', request.name):
+            if not NAME_PATTERN.match(request.name):
                 raise ValueError("アプリ名は英数字とアンダースコアのみ使用できます")
 
             # 入力方法のバリデーション

--- a/lambda/api/app/tests/schemas/test_schema_field.py
+++ b/lambda/api/app/tests/schemas/test_schema_field.py
@@ -11,8 +11,13 @@ from schemas.schema import SchemaField
 
 class TestSchemaField:
     def test_valid_types_pass(self):
-        for t in ("string", "number", "map", "list"):
-            SchemaField(name="f", display_name="F", type=t)
+        # string / number は葉、map は子必須、list は items 必須（意味的整合ルール）
+        SchemaField(name="f", display_name="F", type="string")
+        SchemaField(name="f", display_name="F", type="number")
+        SchemaField(name="m", display_name="M", type="map",
+                    fields=[{"name": "c", "display_name": "C", "type": "string"}])
+        SchemaField(name="l", display_name="L", type="list",
+                    items={"type": "string"})
 
     def test_nested_map_and_list(self):
         f = SchemaField(

--- a/lambda/api/app/tests/schemas/test_schema_semantic.py
+++ b/lambda/api/app/tests/schemas/test_schema_semantic.py
@@ -1,0 +1,126 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import pytest
+from pydantic import ValidationError
+
+from schemas.schema import SchemaField, SchemaSaveRequest
+
+
+def _save_request(fields):
+    return SchemaSaveRequest(
+        name="app1", display_name="App 1", fields=fields,
+        input_methods={"file_upload": True},
+    )
+
+
+def _str_field(name="f", display_name="F"):
+    return {"name": name, "display_name": display_name, "type": "string"}
+
+
+class TestRule1NonEmptySchema:
+    def test_empty_fields_rejected(self):
+        with pytest.raises(ValidationError):
+            _save_request([])
+
+    def test_one_field_ok(self):
+        _save_request([_str_field()])
+
+
+class TestRule2FieldName:
+    def test_empty_name_rejected(self):
+        with pytest.raises(ValidationError):
+            SchemaField(name="", display_name="F", type="string")
+
+    @pytest.mark.parametrize("bad", ["a b", "日本語", "field@1", "a-b", "a.b"])
+    def test_invalid_pattern_rejected(self, bad):
+        with pytest.raises(ValidationError):
+            SchemaField(name=bad, display_name="F", type="string")
+
+    @pytest.mark.parametrize("ok", ["a", "field_1", "ABC_123", "_x"])
+    def test_valid_pattern_ok(self, ok):
+        SchemaField(name=ok, display_name="F", type="string")
+
+    def test_nested_map_child_name_validated(self):
+        with pytest.raises(ValidationError):
+            SchemaField(name="m", display_name="M", type="map",
+                        fields=[{"name": "bad name", "display_name": "C", "type": "string"}])
+
+
+class TestRule3SiblingUnique:
+    def test_top_level_duplicate_rejected(self):
+        with pytest.raises(ValidationError):
+            _save_request([_str_field(name="a"), _str_field(name="a")])
+
+    def test_same_name_different_parent_ok(self):
+        # 親が違えば同名は許可（グローバル一意ではない）
+        _save_request([
+            {"name": "m1", "display_name": "M1", "type": "map",
+             "fields": [_str_field(name="x")]},
+            {"name": "m2", "display_name": "M2", "type": "map",
+             "fields": [_str_field(name="x")]},
+        ])
+
+    def test_map_child_duplicate_rejected(self):
+        with pytest.raises(ValidationError):
+            SchemaField(name="m", display_name="M", type="map",
+                        fields=[_str_field(name="a"), _str_field(name="a")])
+
+
+class TestRule4Structure:
+    def test_map_without_fields_rejected(self):
+        with pytest.raises(ValidationError):
+            SchemaField(name="m", display_name="M", type="map")
+
+    def test_map_with_empty_fields_rejected(self):
+        with pytest.raises(ValidationError):
+            SchemaField(name="m", display_name="M", type="map", fields=[])
+
+    def test_map_with_items_rejected(self):
+        with pytest.raises(ValidationError):
+            SchemaField(name="m", display_name="M", type="map",
+                        fields=[_str_field()], items={"type": "string"})
+
+    def test_list_without_items_rejected(self):
+        with pytest.raises(ValidationError):
+            SchemaField(name="l", display_name="L", type="list")
+
+    def test_list_with_fields_rejected(self):
+        with pytest.raises(ValidationError):
+            SchemaField(name="l", display_name="L", type="list",
+                        items={"type": "string"}, fields=[_str_field()])
+
+    def test_string_with_fields_rejected(self):
+        with pytest.raises(ValidationError):
+            SchemaField(name="s", display_name="S", type="string", fields=[_str_field()])
+
+    def test_number_with_items_rejected(self):
+        with pytest.raises(ValidationError):
+            SchemaField(name="n", display_name="N", type="number", items={"type": "string"})
+
+    def test_list_item_type_list_rejected(self):
+        with pytest.raises(ValidationError):
+            SchemaField(name="l", display_name="L", type="list", items={"type": "list"})
+
+    def test_list_item_map_without_fields_rejected(self):
+        with pytest.raises(ValidationError):
+            SchemaField(name="l", display_name="L", type="list", items={"type": "map"})
+
+    def test_valid_list_of_map_ok(self):
+        # 明細行の典型パターン（list -> map -> string）は通る
+        f = SchemaField(name="items", display_name="明細", type="list",
+                        items={"type": "map",
+                               "fields": [_str_field(name="d", display_name="品目")]})
+        assert f.items.fields[0].name == "d"
+
+
+class TestRule5DisplayName:
+    def test_empty_display_name_rejected(self):
+        with pytest.raises(ValidationError):
+            SchemaField(name="f", display_name="", type="string")
+
+    def test_whitespace_display_name_rejected(self):
+        with pytest.raises(ValidationError):
+            SchemaField(name="f", display_name="   ", type="string")

--- a/web/src/pages/schema/SchemaGenerator.tsx
+++ b/web/src/pages/schema/SchemaGenerator.tsx
@@ -4,7 +4,8 @@ import { Info } from "lucide-react";
 import SchemaPreview from "./SchemaPreview";
 import SchemaFieldsEditor from "./SchemaFieldsEditor";
 import { Field } from "../../types/app-schema";
-import api from "../../services/api";
+import api, { extractApiErrorMessage } from "../../services/api";
+import { validateSchemaFields, isValidAppName } from "../../utils/schemaValidation";
 import { useAppContext } from "../../contexts/AppContext";
 import { Alert, Button, Skeleton } from "../../components/ui";
 
@@ -156,6 +157,11 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
   const validateAppName = (name: string): boolean => {
     if (!name) {
       setAppNameError("アプリ名は必須です");
+      return false;
+    }
+    // 形式チェック（バックの NAME_PATTERN と同期。従来はバック 400 でしか弾けなかった）
+    if (!isValidAppName(name)) {
+      setAppNameError("アプリ名は英数字とアンダースコアのみ使用できます");
       return false;
     }
     // 新規作成モードのみ重複チェック
@@ -324,7 +330,7 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
       }
     } catch (err: any) {
       console.error("スキーマ生成エラー:", err);
-      setError(`スキーマ生成に失敗しました: ${err.response?.data?.detail || err.message}`);
+      setError(`スキーマ生成に失敗しました:\n${extractApiErrorMessage(err)}`);
     } finally {
       setIsGenerating(false);
     }
@@ -347,6 +353,14 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
     // アプリ名の検証
     if (!validateAppName(appName)) {
       setError(appNameError || "アプリ名が無効です");
+      setSuccessMessage(null);
+      return;
+    }
+
+    // フィールドの意味的検証（バックの pydantic ルールをミラー。保存前に問題を洗い出す）
+    const fieldErrors = validateSchemaFields(generatedSchema?.fields || []);
+    if (fieldErrors.length > 0) {
+      setError(`スキーマに問題があります:\n${fieldErrors.join("\n")}`);
       setSuccessMessage(null);
       return;
     }
@@ -418,8 +432,8 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
       }, 3000);
     } catch (err: any) {
       console.error("スキーマ保存エラー:", err);
-      const errorMessage = err.response?.data?.detail || err.message || "不明なエラーが発生しました";
-      setError(`スキーマの保存に失敗しました: ${errorMessage}`);
+      const errorMessage = extractApiErrorMessage(err);
+      setError(`スキーマの保存に失敗しました:\n${errorMessage}`);
       setSuccessMessage(null); // 成功メッセージをクリア
     } finally {
       setIsSaving(false);
@@ -832,7 +846,7 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
 
         {error && (
           <Alert type="error" className="mb-4">
-            <span className="block sm:inline">{error}</span>
+            <span className="block sm:inline whitespace-pre-line">{error}</span>
           </Alert>
         )}
 

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -78,4 +78,29 @@ api.interceptors.response.use(
   }
 );
 
+// pydantic v2 の 422 detail 1件を表示用の1行に整形する。
+// - ValueError は msg が "Value error, <本文>" になるため接頭辞を除去
+// - 必須キー欠落（type: "missing"）は英語 "Field required" になるため日本語化
+function formatDetailEntry(d: any): string {
+  if (typeof d === 'string') return d;
+  if (d?.type === 'missing') return '必須項目が入力されていません';
+  const msg: string = d?.msg || '';
+  return msg.replace(/^Value error,\s*/, '');
+}
+
+/**
+ * API エラーから表示用メッセージを取り出す。
+ * FastAPI の 422 は detail が配列（[{loc, msg, type}, ...]）で返るため、
+ * そのままだと "[object Object]" になる。string / 配列 の両方を読める形に整形する。
+ */
+export function extractApiErrorMessage(err: any, fallback = '不明なエラーが発生しました'): string {
+  const detail = err?.response?.data?.detail;
+  if (typeof detail === 'string') return detail;
+  if (Array.isArray(detail)) {
+    const lines = detail.map(formatDetailEntry).filter(Boolean);
+    if (lines.length > 0) return lines.join('\n');
+  }
+  return err?.message || fallback;
+}
+
 export default api;

--- a/web/src/utils/schemaValidation.ts
+++ b/web/src/utils/schemaValidation.ts
@@ -1,0 +1,115 @@
+/**
+ * スキーマ保存前のクライアント側検証。
+ * バックエンド（lambda/api/app/schemas/schema.py の pydantic validators）と同じ
+ * 意味的ルールをミラーし、保存前に日本語メッセージで問題を洗い出す。
+ * バックが最終防御（422）なので、ここは UX 向上のための事前チェック。
+ */
+import { Field } from '../types/app-schema';
+
+// フィールド名 / アプリ名に許可する文字。英数字とアンダースコアのみ。
+// keep in sync: lambda/api/app/schemas/schema.py NAME_PATTERN
+export const NAME_PATTERN = /^[a-zA-Z0-9_]+$/;
+
+/** アプリ名の形式チェック（バックの NAME_PATTERN と同期）。 */
+export function isValidAppName(name: string): boolean {
+  return NAME_PATTERN.test(name);
+}
+
+// 同一階層のフィールド名重複を検出してメッセージを push する。
+function checkSiblingNames(fields: Field[], errors: string[]): void {
+  const seen = new Set<string>();
+  for (const f of fields) {
+    if (seen.has(f.name)) {
+      errors.push(`同じ階層でフィールド名が重複しています: ${f.name}`);
+    }
+    seen.add(f.name);
+  }
+}
+
+// 1つの Field ノードを検証（name / display_name / 型別構造）。再帰。
+function validateField(field: Field, errors: string[]): void {
+  const label = field.display_name || field.name || '(名称未設定)';
+
+  // name（rule 2）
+  if (!field.name) {
+    errors.push('フィールド名は必須です');
+  } else if (!NAME_PATTERN.test(field.name)) {
+    errors.push(`フィールド名は英数字とアンダースコアのみ使用できます: ${field.name}`);
+  }
+  // display_name（rule 5）
+  if (!field.display_name || !field.display_name.trim()) {
+    errors.push(`表示名は必須です（フィールド: ${field.name || '(名称未設定)'}）`);
+  }
+
+  // 型別構造（rule 4）
+  if (field.type === 'map') {
+    if (!field.fields || field.fields.length === 0) {
+      errors.push(`map 型「${label}」には子フィールドが必要です`);
+    } else {
+      checkSiblingNames(field.fields, errors);
+      field.fields.forEach((c) => validateField(c, errors));
+    }
+    if (field.items) {
+      errors.push(`map 型「${label}」に items は指定できません`);
+    }
+  } else if (field.type === 'list') {
+    if (!field.items) {
+      errors.push(`list 型「${label}」には要素定義が必要です`);
+    } else {
+      validateItems(field.items, label, errors);
+    }
+    if (field.fields) {
+      errors.push(`list 型「${label}」に fields は指定できません`);
+    }
+  } else {
+    // string / number
+    if (field.fields || field.items) {
+      errors.push(`${field.type} 型「${label}」に子フィールドや要素定義は指定できません`);
+    }
+  }
+}
+
+// list の items（FieldItems 相当。name/display_name を持たない別形）を検証。
+// 型は {type, fields?} で items キーを持たないため、list-in-list はそもそも表現不能
+// （エディタも要素型から list を除外済み）。防御的にチェックのみ残す。
+function validateItems(
+  items: NonNullable<Field['items']>,
+  parentLabel: string,
+  errors: string[],
+): void {
+  if (items.type === 'list') {
+    errors.push(`list「${parentLabel}」の要素として list 型は指定できません`);
+    return;
+  }
+  if (items.type === 'map') {
+    if (!items.fields || items.fields.length === 0) {
+      errors.push(`list「${parentLabel}」の map 要素には子フィールドが必要です`);
+    } else {
+      checkSiblingNames(items.fields, errors);
+      items.fields.forEach((c) => validateField(c, errors));
+    }
+  } else {
+    // string / number 要素
+    if (items.fields) {
+      errors.push(`list「${parentLabel}」の ${items.type} 要素に子フィールドは指定できません`);
+    }
+  }
+}
+
+/**
+ * スキーマの fields を検証し、日本語エラーメッセージの配列を返す（空配列 = 問題なし）。
+ * バックの rules 1〜5 をミラー。
+ */
+export function validateSchemaFields(fields: Field[]): string[] {
+  const errors: string[] = [];
+  // rule 1: 最低1件
+  if (!fields || fields.length === 0) {
+    errors.push('スキーマには最低1つのフィールドが必要です');
+    return errors;
+  }
+  // rule 3: top レベルの重複
+  checkSiblingNames(fields, errors);
+  // 各フィールド
+  fields.forEach((f) => validateField(f, errors));
+  return errors;
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Follow-up to PR #75, which typed schema fields with pydantic (`SchemaField`/`FieldItems`, `extra=forbid`, `type` Literal). That gave structural integrity (unknown keys / wrong types rejected) but NOT semantic integrity. Since the schema is now user-editable (it originally was backend-generated only), a user could still save schemas that break downstream extraction: empty schema, empty/duplicate/non-identifier field names, a `map` with no children, a `list` with no items, etc.

This PR adds full semantic validation, enforced at the request boundary (backend, source of truth) and mirrored client-side for immediate feedback.

### Rules enforced

1. Schema must have at least one field.
2. Field name is required and must match `^[a-zA-Z0-9_]+$` (same pattern as the app name), at every nesting level.
3. Field names must be unique among siblings (per-level, not global).
4. Type/structure coherence: `map` requires non-empty `fields` and forbids `items`; `list` requires `items` and forbids `fields`; `string`/`number` forbid both. List items may not themselves be `list`, and a `map` item requires non-empty `fields`.
5. `display_name` is required (whitespace-only rejected).

### Backend (source of truth)

- `schemas/schema.py`: pydantic `field_validator`/`model_validator` on `SchemaField`, `FieldItems`, and `SchemaSaveRequest`. Structural error messages embed the field's `display_name` so the offending field is identifiable. The name regex is consolidated into a single `NAME_PATTERN` constant, reused by `schema_service.py` (previously duplicated).
- Validation lives only at the request models (both POST `/apps` and PUT `/apps/{name}` bind `SchemaSaveRequest`), not in the service, to keep a single source of truth. Read paths do not run pydantic, so existing data still loads and extraction is unaffected.

### Frontend (pre-save UX)

- New `utils/schemaValidation.ts` mirrors the rules and returns Japanese messages; `SchemaGenerator` runs it before calling the API and shows the list in the existing Alert (no editor refactor, no inline field UI). The app-name format check (previously backend-only) is also surfaced client-side.
- `services/api.ts` gains `extractApiErrorMessage`, which normalizes FastAPI 422 responses (detail is an array) into readable text — previously such errors rendered as `[object Object]`. It also strips pydantic's `Value error, ` prefix and localizes the required-field message.

### Compatibility note

Existing stored schemas were checked against the new rules: valid ones still load and re-save fine. One pre-existing test app has a `map` field with no children; it loads normally (reads are not validated) but will require fixing that field before it can be re-saved. No data migration is performed.

### Verification

- Backend: pytest (55 passed, incl. a new semantic test suite covering each rule pass/fail and an updated existing test). pyflakes clean.
- Frontend: `tsc` clean.
- Deployed to a test environment; end-to-end browser verification to follow.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.