### PR TITLE
refactor: unify API error handling with domain exceptions and normalized responses

### DIFF
--- a/.kiro/steering/coding-rules.md
+++ b/.kiro/steering/coding-rules.md
@@ -16,6 +16,7 @@ inclusion: always
 - **import はモジュール先頭**: 循環参照を避ける場合を除き、関数内での遅延 import は禁止。
 - **変更後は pyflakes 実行**: 変更したファイルに対して `python -m pyflakes` を実行し、未使用 import や構文エラーがないことを確認する。
 - **enum 的な値は `StrEnum` にする**: status / mode / type など取りうる値が決まった文字列は、リテラルを散在させず `StrEnum` に集約し、write 前に検証する（`XxxStatus(value)` が無効値で ValueError）。
+- **エラーは domain 例外で表す**: services / repositories は `exceptions.py` の `AppError` 系（`NotFoundError` 等）を raise する。`HTTPException` は routers / dependencies のみ。HTTP 変換とレスポンス整形（`{detail, code}`）は `errors.py` の例外ハンドラに一元化し、各所で try/except して 500 に包み直さない。
 
 ## フロントエンド (React TypeScript)
 
@@ -23,6 +24,7 @@ inclusion: always
 - **型は camelCase 統一**: API レスポンスの snake_case はサービス層で変換。
 - **巨大コンポーネントは分割**: 複雑なステート管理・ポーリングはカスタムフックに切り出す。
 - **enum 的な値は union 型で締める**: status / type 等は `string` でなく取りうる値の union にする。
+- **API エラー表示は `err.userMessage` を使う**: 各所で `detail` / `err.message` を手整形しない。表示用メッセージは axios interceptor が付与する。
 
 ## CDK (TypeScript)
 

--- a/lambda/api/app/errors.py
+++ b/lambda/api/app/errors.py
@@ -1,36 +1,30 @@
-"""API エラーレスポンスを `{"detail": "<表示メッセージ>", "code": "<機械判定コード|null>"}` の1形に統一する。
-
-既存の `raise HTTPException(...)` は変更せず、ここでレスポンスを包む。
-"""
+"""API エラーレスポンスを `{"detail": "<表示メッセージ>", "code": "<機械判定コード|null>"}` の1形に統一する。"""
 import logging
 
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
-# fastapi.HTTPException はこのサブクラス。フレームワークが投げる 404/405 は
-# 純 starlette の HTTPException なので、必ず starlette の base で登録する。
+# フレームワークが投げる 404/405 は starlette の HTTPException なので base で登録する
+# （fastapi.HTTPException はそのサブクラス）。
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from exceptions import AppError
 
 logger = logging.getLogger(__name__)
 
-# クライアントに内部情報を出さないための汎用 5xx メッセージ
+# 内部情報を出さないための汎用 5xx メッセージ
 _INTERNAL_MESSAGE = "予期しないエラーが発生しました"
 
 
 def _format_validation_message(errors: list) -> str:
-    """pydantic の検証エラー list を表示用の1メッセージに集約する。
-
-    loc（フィールドパス）は使わず msg のみを日本語向けに整形して改行結合する。
-    """
+    """pydantic の検証エラーを表示用の1メッセージ（改行区切り）に集約する。"""
     lines = []
     for e in errors:
         if e.get("type") == "missing":
             lines.append("必須項目が入力されていません")
             continue
         msg = e.get("msg", "")
-        # pydantic は ValueError を "Value error, <本文>" として返すため接頭辞を除去
+        # pydantic は ValueError を "Value error, <本文>" として返すため接頭辞を除く
         msg = msg.replace("Value error, ", "", 1) if msg.startswith("Value error, ") else msg
         if msg:
             lines.append(msg)
@@ -38,17 +32,15 @@ def _format_validation_message(errors: list) -> str:
 
 
 def register_error_handlers(app: FastAPI) -> None:
-    """アプリにエラーハンドラを登録する（main.py から呼ぶ）。
+    """エラーハンドラを登録する。
 
-    @app.exception_handler で登録するため、これらは Starlette の ExceptionMiddleware
-    層（CORSMiddleware の内側）で実行され、エラーレスポンスにも CORS ヘッダが付く。
-    エラー処理を独自 middleware として実装すると CORS ヘッダが落ちるため、必ずここで行う。
+    @app.exception_handler で登録すると CORSMiddleware の内側で実行され、
+    エラーレスポンスにも CORS ヘッダが付く（独自 middleware にすると CORS が落ちる）。
     """
 
     @app.exception_handler(AppError)
     async def app_error_handler(request: Request, exc: AppError):
-        # code を持つ 5xx（endpoint_not_ready 等）は意図的なエラーなので message/code を保持。
-        # code 無しの 5xx（＝素の AppError 等）だけ内部情報を隠して汎用メッセージにする。
+        # code を持たない 5xx はサーバー障害なので内部情報を隠す
         if exc.status_code >= 500 and not exc.code:
             logger.error("5xx AppError at %s: %r", request.url.path, str(exc))
             return JSONResponse(
@@ -65,9 +57,8 @@ def register_error_handlers(app: FastAPI) -> None:
         detail = exc.detail
         headers = getattr(exc, "headers", None)
 
-        # {"error": "...", "message": "..."} 形（endpoint_not_ready 等）は、機械判定コードと
-        # 表示メッセージを保持する。ただし 5xx で保持するのは明示コード(error)を持つ意図的な
-        # エラーのみ。error 無しの 5xx dict は下の 5xx マスクに流し、内部情報の漏洩を防ぐ。
+        # dict detail は {"error": code, "message": text} 形として code/message を取り出す。
+        # 5xx で通すのは code を持つ場合のみ（それ以外の 5xx は下でマスクして内部情報を守る）。
         if isinstance(detail, dict) and (exc.status_code < 500 or detail.get("error")):
             return JSONResponse(
                 status_code=exc.status_code,
@@ -75,7 +66,7 @@ def register_error_handlers(app: FastAPI) -> None:
                 headers=headers,
             )
 
-        # 明示コードを持たない 5xx は内部情報を隠して汎用メッセージに（元 detail はログのみ）
+        # code を持たない 5xx はサーバー障害なので内部情報を隠す
         if exc.status_code >= 500:
             logger.error("5xx HTTPException at %s: %r", request.url.path, detail)
             return JSONResponse(
@@ -84,7 +75,6 @@ def register_error_handlers(app: FastAPI) -> None:
                 headers=headers,
             )
 
-        # 4xx の string detail（大多数）
         return JSONResponse(
             status_code=exc.status_code,
             content={"detail": str(detail), "code": None},
@@ -93,7 +83,7 @@ def register_error_handlers(app: FastAPI) -> None:
 
     @app.exception_handler(RequestValidationError)
     async def validation_exception_handler(request: Request, exc: RequestValidationError):
-        # 生の検証エラーはデバッグ用にサーバーログへ残す（クライアントには集約文字列のみ）
+        # 生の検証エラーはデバッグ用にログへ残す（クライアントには集約文字列のみ返す）
         logger.info("Validation error at %s: %s", request.url.path, exc.errors())
         return JSONResponse(
             status_code=422,
@@ -102,7 +92,7 @@ def register_error_handlers(app: FastAPI) -> None:
 
     @app.exception_handler(Exception)
     async def unhandled_exception_handler(request: Request, exc: Exception):
-        # router の except で拾えなかった例外（依存解決・middleware 等）の最終防御
+        # 想定外の例外の最終防御。内部情報はログのみに残す
         logger.exception("Unhandled exception at %s", request.url.path)
         return JSONResponse(
             status_code=500,

--- a/lambda/api/app/errors.py
+++ b/lambda/api/app/errors.py
@@ -1,0 +1,110 @@
+"""API エラーレスポンスを `{"detail": "<表示メッセージ>", "code": "<機械判定コード|null>"}` の1形に統一する。
+
+既存の `raise HTTPException(...)` は変更せず、ここでレスポンスを包む。
+"""
+import logging
+
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+# fastapi.HTTPException はこのサブクラス。フレームワークが投げる 404/405 は
+# 純 starlette の HTTPException なので、必ず starlette の base で登録する。
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from exceptions import AppError
+
+logger = logging.getLogger(__name__)
+
+# クライアントに内部情報を出さないための汎用 5xx メッセージ
+_INTERNAL_MESSAGE = "予期しないエラーが発生しました"
+
+
+def _format_validation_message(errors: list) -> str:
+    """pydantic の検証エラー list を表示用の1メッセージに集約する。
+
+    loc（フィールドパス）は使わず msg のみを日本語向けに整形して改行結合する。
+    """
+    lines = []
+    for e in errors:
+        if e.get("type") == "missing":
+            lines.append("必須項目が入力されていません")
+            continue
+        msg = e.get("msg", "")
+        # pydantic は ValueError を "Value error, <本文>" として返すため接頭辞を除去
+        msg = msg.replace("Value error, ", "", 1) if msg.startswith("Value error, ") else msg
+        if msg:
+            lines.append(msg)
+    return "\n".join(lines) if lines else "入力内容が不正です"
+
+
+def register_error_handlers(app: FastAPI) -> None:
+    """アプリにエラーハンドラを登録する（main.py から呼ぶ）。
+
+    @app.exception_handler で登録するため、これらは Starlette の ExceptionMiddleware
+    層（CORSMiddleware の内側）で実行され、エラーレスポンスにも CORS ヘッダが付く。
+    エラー処理を独自 middleware として実装すると CORS ヘッダが落ちるため、必ずここで行う。
+    """
+
+    @app.exception_handler(AppError)
+    async def app_error_handler(request: Request, exc: AppError):
+        # code を持つ 5xx（endpoint_not_ready 等）は意図的なエラーなので message/code を保持。
+        # code 無しの 5xx（＝素の AppError 等）だけ内部情報を隠して汎用メッセージにする。
+        if exc.status_code >= 500 and not exc.code:
+            logger.error("5xx AppError at %s: %r", request.url.path, str(exc))
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"detail": _INTERNAL_MESSAGE, "code": "internal_error"},
+            )
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"detail": str(exc), "code": exc.code},
+        )
+
+    @app.exception_handler(StarletteHTTPException)
+    async def http_exception_handler(request: Request, exc: StarletteHTTPException):
+        detail = exc.detail
+        headers = getattr(exc, "headers", None)
+
+        # {"error": "...", "message": "..."} 形（endpoint_not_ready 等）は、機械判定コードと
+        # 表示メッセージを保持する。ただし 5xx で保持するのは明示コード(error)を持つ意図的な
+        # エラーのみ。error 無しの 5xx dict は下の 5xx マスクに流し、内部情報の漏洩を防ぐ。
+        if isinstance(detail, dict) and (exc.status_code < 500 or detail.get("error")):
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"detail": detail.get("message") or str(detail), "code": detail.get("error")},
+                headers=headers,
+            )
+
+        # 明示コードを持たない 5xx は内部情報を隠して汎用メッセージに（元 detail はログのみ）
+        if exc.status_code >= 500:
+            logger.error("5xx HTTPException at %s: %r", request.url.path, detail)
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"detail": _INTERNAL_MESSAGE, "code": "internal_error"},
+                headers=headers,
+            )
+
+        # 4xx の string detail（大多数）
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"detail": str(detail), "code": None},
+            headers=headers,
+        )
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_exception_handler(request: Request, exc: RequestValidationError):
+        # 生の検証エラーはデバッグ用にサーバーログへ残す（クライアントには集約文字列のみ）
+        logger.info("Validation error at %s: %s", request.url.path, exc.errors())
+        return JSONResponse(
+            status_code=422,
+            content={"detail": _format_validation_message(exc.errors()), "code": "validation_error"},
+        )
+
+    @app.exception_handler(Exception)
+    async def unhandled_exception_handler(request: Request, exc: Exception):
+        # router の except で拾えなかった例外（依存解決・middleware 等）の最終防御
+        logger.exception("Unhandled exception at %s", request.url.path)
+        return JSONResponse(
+            status_code=500,
+            content={"detail": _INTERNAL_MESSAGE, "code": "internal_error"},
+        )

--- a/lambda/api/app/exceptions.py
+++ b/lambda/api/app/exceptions.py
@@ -1,0 +1,53 @@
+"""アプリのドメイン例外。
+
+services / repositories はこれらを raise し、errors.py のハンドラが
+HTTP レスポンス（status / code / message）へマップする。
+HTTPException は routers / dependencies のみで使い、ここには持ち込まない。
+
+直接 `AppError` を raise しないこと（意味が曖昧な 500 になる）。用途に応じたサブクラスを使う。
+"""
+
+
+class AppError(Exception):
+    """ドメイン例外の基底。status_code と機械判定用 code を持つ。"""
+    status_code = 500
+    code = "internal_error"
+
+    def __init__(self, message: str = ""):
+        super().__init__(message)
+
+
+class NotFoundError(AppError):
+    """リソースが見つからない。"""
+    status_code = 404
+    code = "not_found"
+
+
+class BadRequestError(AppError):
+    """リクエストが不正（業務ルール上の入力エラー）。"""
+    status_code = 400
+    code = "bad_request"
+
+
+class ForbiddenError(AppError):
+    """権限不足。"""
+    status_code = 403
+    code = "forbidden"
+
+
+class ConflictError(AppError):
+    """リソースの状態競合。"""
+    status_code = 409
+    code = "conflict"
+
+
+class LastOwnerError(AppError):
+    """最後のオーナーを削除しようとした。"""
+    status_code = 400
+    code = "last_owner"
+
+
+class EndpointNotReadyError(AppError):
+    """OCR エンドポイントが起動中。"""
+    status_code = 503
+    code = "endpoint_not_ready"

--- a/lambda/api/app/main.py
+++ b/lambda/api/app/main.py
@@ -16,12 +16,16 @@ from services.sharing_service import SharingService
 
 from routers import health, images, jobs, system, tools, apps
 from routers import admin, user, sharing
+from errors import register_error_handlers
 
 # アプリケーション全体のログレベル設定
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 app = FastAPI()
+
+# エラーレスポンスを統一形（{detail, code}）に正規化するハンドラを登録
+register_error_handlers(app)
 
 # バックグラウンドタスク拡張機能を初期化
 background_task = BackgroundTaskExtension()

--- a/lambda/api/app/repositories/image_repository.py
+++ b/lambda/api/app/repositories/image_repository.py
@@ -23,7 +23,7 @@ def get_images_table():
     table_name = settings.IMAGES_TABLE_NAME
     if not table_name:
         logger.error("IMAGES_TABLE_NAME 環境変数が設定されていません")
-        raise ValueError("IMAGES_TABLE_NAME environment variable is not set")
+        raise RuntimeError("IMAGES_TABLE_NAME environment variable is not set")
 
     return dynamodb_resource.Table(table_name)
 

--- a/lambda/api/app/repositories/job_repository.py
+++ b/lambda/api/app/repositories/job_repository.py
@@ -6,6 +6,7 @@ from botocore.exceptions import ClientError
 from datetime import datetime
 import uuid
 from config import settings
+from exceptions import NotFoundError, BadRequestError
 
 logger = logging.getLogger(__name__)
 
@@ -19,8 +20,11 @@ class JobStatus(StrEnum):
 
 
 def validate_job_status(status: str) -> None:
-    """無効なジョブステータス値なら ValueError。"""
-    JobStatus(status)
+    """無効なジョブステータス値なら BadRequestError。"""
+    try:
+        JobStatus(status)
+    except ValueError:
+        raise BadRequestError(f"不正なジョブステータスです: {status}")
 
 
 class JobType(StrEnum):
@@ -37,8 +41,11 @@ class SuggestionStatus(StrEnum):
 
 
 def validate_suggestion_status(status: str) -> None:
-    """無効な提案ステータス値なら ValueError。"""
-    SuggestionStatus(status)
+    """無効な提案ステータス値なら BadRequestError。"""
+    try:
+        SuggestionStatus(status)
+    except ValueError:
+        raise BadRequestError(f"不正な提案ステータスです: {status}")
 
 
 def get_jobs_table():
@@ -46,7 +53,7 @@ def get_jobs_table():
     table_name = settings.JOBS_TABLE_NAME
     if not table_name:
         logger.error("JOBS_TABLE_NAME 環境変数が設定されていません")
-        raise ValueError("JOBS_TABLE_NAME environment variable is not set")
+        raise RuntimeError("JOBS_TABLE_NAME environment variable is not set")
     return dynamodb_resource.Table(table_name)
 
 
@@ -55,7 +62,7 @@ def get_images_table():
     table_name = settings.IMAGES_TABLE_NAME
     if not table_name:
         logger.error("IMAGES_TABLE_NAME 環境変数が設定されていません")
-        raise ValueError("IMAGES_TABLE_NAME environment variable is not set")
+        raise RuntimeError("IMAGES_TABLE_NAME environment variable is not set")
     return dynamodb_resource.Table(table_name)
 
 
@@ -132,11 +139,11 @@ def update_suggestion_status(image_id: str, suggestion_index: int, status: str) 
     validate_suggestion_status(status)
     job = get_latest_agent_job_by_image_id(image_id)
     if not job:
-        raise ValueError("No agent job found for this image")
+        raise NotFoundError("この画像のエージェントジョブが見つかりません")
 
     suggestions = job.get("suggestions", [])
     if suggestion_index < 0 or suggestion_index >= len(suggestions):
-        raise ValueError(f"Invalid suggestion index: {suggestion_index}")
+        raise BadRequestError(f"提案のインデックスが不正です: {suggestion_index}")
 
     # Atomically update single element using DynamoDB path expression
     table = get_jobs_table()

--- a/lambda/api/app/repositories/schema_repository.py
+++ b/lambda/api/app/repositories/schema_repository.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import boto3
 from botocore.exceptions import ClientError
 from clients import dynamodb_resource
+from exceptions import ConflictError
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +14,7 @@ def _get_schemas_table():
     table_name = os.environ.get('SCHEMAS_TABLE_NAME')
     if not table_name:
         logger.error("SCHEMAS_TABLE_NAME 環境変数が設定されていません")
-        raise ValueError("SCHEMAS_TABLE_NAME environment variable is not set")
+        raise RuntimeError("SCHEMAS_TABLE_NAME environment variable is not set")
     return dynamodb_resource.Table(table_name)
 
 
@@ -172,7 +173,7 @@ def create_app_schema(app_name, app_data):
 
     except ClientError as e:
         if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
-            raise ValueError(f"アプリ名 '{app_name}' は既に使用されています")
+            raise ConflictError(f"アプリ名 '{app_name}' は既に使用されています")
         raise
     except Exception as e:
         logger.error(f"スキーマ作成エラー: {str(e)}")

--- a/lambda/api/app/routers/admin.py
+++ b/lambda/api/app/routers/admin.py
@@ -8,7 +8,7 @@ from schemas.admin import (
     UserRoleUpdate, GroupCreate, GroupUpdate, GroupMemberUpdate,
     ToolCreate, ToolUpdate, ToolUserBody, ToolGroupBody,
 )
-from services.admin_service import AdminService, NotFoundError
+from services.admin_service import AdminService
 from services.image_list_service import ImageListService
 from dependencies.services import get_image_list_service, get_admin_service
 
@@ -53,13 +53,8 @@ async def get_group_members(group_id: str, user=Depends(RequireRole("admin")), s
 @router.delete("/groups/{group_id}")
 async def delete_group(group_id: str, user=Depends(RequireRole("admin")), service: AdminService = Depends(get_admin_service)):
     """グループを削除する（auto グループは削除不可）"""
-    try:
-        service.delete_group(group_id)
-        return {"ok": True}
-    except NotFoundError as e:
-        raise HTTPException(404, str(e))
-    except ValueError as e:
-        raise HTTPException(400, str(e))
+    service.delete_group(group_id)
+    return {"ok": True}
 
 
 @router.patch("/groups/{group_id}")
@@ -68,14 +63,9 @@ async def update_group(group_id: str, body: GroupUpdate, user=Depends(RequireRol
     updates = body.model_dump(exclude_none=True)
     if not updates:
         raise HTTPException(400, "No fields to update")
-    try:
-        if not service.update_group(group_id, **updates):
-            raise HTTPException(404, "Group not found")
-        return {"ok": True}
-    except NotFoundError as e:
-        raise HTTPException(404, str(e))
-    except ValueError as e:
-        raise HTTPException(400, str(e))
+    if not service.update_group(group_id, **updates):
+        raise HTTPException(404, "Group not found")
+    return {"ok": True}
 
 
 @router.put("/groups/{group_id}/members")

--- a/lambda/api/app/routers/apps.py
+++ b/lambda/api/app/routers/apps.py
@@ -15,7 +15,7 @@ from schemas import (
 )
 from services.schema_service import SchemaService
 from services.s3_sync_service import S3SyncService
-from services.ocr_service import OcrService, EndpointNotReadyError
+from services.ocr_service import OcrService
 from dependencies.services import get_schema_service, get_s3_sync_service, get_ocr_service
 from dependencies.auth import (
     require_user, get_cognito_sub,
@@ -34,102 +34,54 @@ router = APIRouter(tags=["Apps"])
 @router.get("/apps")
 async def get_apps(user=Depends(require_user), service: SchemaService = Depends(get_schema_service)):
     """アプリ一覧を取得する（権限のあるもののみ）"""
-    try:
-        return await service.get_apps_list(
-            user_id=str(user["id"]),
-            role=user["role"],
-        )
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error getting apps list: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    return await service.get_apps_list(
+        user_id=str(user["id"]),
+        role=user["role"],
+    )
 
 
 @router.get("/apps/{app_name}")
 async def get_app_details(app_name: str, user=Depends(RequirePermission("viewer")), service: SchemaService = Depends(get_schema_service)):
     """アプリ詳細を取得する（viewer 以上）"""
-    try:
-        return await service.get_app_details(app_name)
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error getting app details: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    return await service.get_app_details(app_name)
 
 
 @router.get("/apps/{app_name}/fields")
 async def get_app_fields(app_name: str, user=Depends(RequirePermission("viewer")), service: SchemaService = Depends(get_schema_service)):
     """アプリのフィールド一覧を取得する（viewer 以上）"""
-    try:
-        return await service.get_app_fields(app_name)
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error getting app fields: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    return await service.get_app_fields(app_name)
 
 
 @router.get("/apps/{app_name}/custom-prompt")
 async def get_custom_prompt(app_name: str, user=Depends(RequirePermission("viewer")), service: SchemaService = Depends(get_schema_service)):
     """カスタムプロンプトを取得する（viewer 以上）"""
-    try:
-        return await service.get_custom_prompt(app_name)
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error getting custom prompt: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    return await service.get_custom_prompt(app_name)
 
 
 @router.put("/apps/{app_name}/custom-prompt")
 async def update_custom_prompt(app_name: str, request: CustomPromptRequest, user=Depends(RequirePermission("editor")), service: SchemaService = Depends(get_schema_service)):
     """カスタムプロンプトを更新する（editor 以上）"""
-    try:
-        await service.update_custom_prompt(app_name, request)
-        return {"status": "success", "message": "Custom prompt updated successfully"}
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error updating custom prompt: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    await service.update_custom_prompt(app_name, request)
+    return {"status": "success", "message": "Custom prompt updated successfully"}
 
 
 @router.post("/apps")
 async def create_app(request: SchemaSaveRequest, user=Depends(RequireRole("author")), service: SchemaService = Depends(get_schema_service)):
     """アプリを新規作成する（author 以上）"""
-    try:
-        return await service.save_schema(request, user_id=str(user["id"]))
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error creating app: {str(e)}")
-        raise HTTPException(status_code=400, detail=str(e))
+    return await service.save_schema(request, user_id=str(user["id"]))
 
 
 @router.put("/apps/{app_name}")
 async def update_app(app_name: str, request: SchemaSaveRequest, user=Depends(RequirePermission("editor")), service: SchemaService = Depends(get_schema_service)):
     """既存アプリを更新する（editor 以上）"""
-    try:
-        return await service.update_schema(app_name, request)
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error updating app: {str(e)}")
-        raise HTTPException(status_code=400, detail=str(e))
+    return await service.update_schema(app_name, request)
 
 
 @router.delete("/apps/{app_name}")
 async def delete_app(app_name: str, user=Depends(RequirePermission("owner")), service: SchemaService = Depends(get_schema_service)):
     """アプリを削除する（owner 以上）"""
-    try:
-        await service.delete_app(app_name)
-        return {"status": "success", "message": f"App '{app_name}' deleted successfully"}
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error deleting app: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    await service.delete_app(app_name)
+    return {"status": "success", "message": f"App '{app_name}' deleted successfully"}
 
 
 # === Schema ===
@@ -137,13 +89,7 @@ async def delete_app(app_name: str, user=Depends(RequirePermission("owner")), se
 @router.post("/apps/schema/upload-url")
 async def generate_app_schema_presigned_url(request: PresignedUrlRequest, user=Depends(RequireRole("author")), service: SchemaService = Depends(get_schema_service)):
     """アプリスキーマ用の署名付きURLを生成する（author 以上）"""
-    try:
-        return await service.generate_schema_presigned_url(request)
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error generating app schema presigned URL: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    return await service.generate_schema_presigned_url(request)
 
 
 @router.get("/apps/{app_name}/sample-image-url")
@@ -152,15 +98,7 @@ async def get_app_sample_image_url(app_name: str, user=Depends(RequirePermission
 
     サンプル画像が未紐付けの場合は {"url": null} を返す。
     """
-    try:
-        return await service.get_sample_image_url(app_name)
-    except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error getting sample image url: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    return await service.get_sample_image_url(app_name)
 
 
 @router.post("/apps/{app_name}/schema/generate", response_model=SchemaGenerateStartResponse)
@@ -173,13 +111,7 @@ async def generate_app_schema(app_name: str, request: SchemaGenerateRequest, use
 
     app_name は URL 上のみで、実際のスキーマ生成では使わない (生成後にユーザーが指定)。
     """
-    try:
-        return await service.start_schema_generation(request)
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error starting schema generation: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    return await service.start_schema_generation(request)
 
 
 @router.get("/apps/schema/generate/{job_id}", response_model=SchemaGenerateStatusResponse)
@@ -191,15 +123,7 @@ async def get_app_schema_generation_status(job_id: str, user=Depends(RequireRole
     - completed: 完了 (result に {"fields": [...]} が入る)
     - failed: 失敗 (error にメッセージ)
     """
-    try:
-        return await service.get_schema_generation_result(job_id)
-    except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error getting schema generation status: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    return await service.get_schema_generation_result(job_id)
 
 
 # === Batch Jobs ===
@@ -211,20 +135,9 @@ async def start_batch_job(
     service: OcrService = Depends(get_ocr_service),
 ):
     """バッチ一括パイプライン起動（OCR→抽出→Agent）"""
-    try:
-        request = OcrStartRequest(app_name=app_name)
-        result = await service.start_step_functions_job(request)
-        return JobStartResponse(jobId=result["jobId"])
-    except EndpointNotReadyError as e:
-        raise HTTPException(
-            status_code=503,
-            detail={"error": "endpoint_not_ready", "message": str(e)}
-        )
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"Error starting batch job: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    request = OcrStartRequest(app_name=app_name)
+    result = await service.start_step_functions_job(request)
+    return JobStartResponse(jobId=result["jobId"])
 
 
 # === S3 Sync ===
@@ -237,11 +150,7 @@ async def sync_s3_files(
     service: S3SyncService = Depends(get_s3_sync_service),
 ):
     """S3バケットからファイルを同期する"""
-    try:
-        return await service.sync_s3_files(app_name, prefix)
-    except Exception as e:
-        logger.error(f"Error syncing S3 files: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    return await service.sync_s3_files(app_name, prefix)
 
 
 @router.post("/apps/{app_name}/s3-sync/import")
@@ -253,12 +162,8 @@ async def import_s3_file(
     service: S3SyncService = Depends(get_s3_sync_service),
 ):
     """S3バケットからファイルをインポートしてOCR処理を開始する"""
-    try:
-        sub = get_cognito_sub(req)
-        return await service.import_s3_file(app_name, body.model_dump(), uploaded_by=sub)
-    except Exception as e:
-        logger.error(f"Error importing S3 file: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    sub = get_cognito_sub(req)
+    return await service.import_s3_file(app_name, body.model_dump(), uploaded_by=sub)
 
 
 @router.get("/apps/{app_name}/s3-sync/files")
@@ -269,11 +174,7 @@ async def list_s3_files(
     service: S3SyncService = Depends(get_s3_sync_service),
 ):
     """S3ファイル一覧を重複チェック付きで取得する"""
-    try:
-        return await service.get_files_with_duplicate_check(app_name, prefix)
-    except Exception as e:
-        logger.error(f"Error listing S3 files: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    return await service.get_files_with_duplicate_check(app_name, prefix)
 
 
 # === Usecase Tools ===

--- a/lambda/api/app/routers/images.py
+++ b/lambda/api/app/routers/images.py
@@ -11,7 +11,7 @@ from schemas import (
     OcrResultResponse,
     ProcessRequest, VerificationRequest, SuggestionStatusUpdate,
 )
-from services.ocr_service import OcrService, EndpointNotReadyError
+from services.ocr_service import OcrService
 from services.upload_service import UploadService
 from services.image_list_service import ImageListService
 from services.extraction_service import ExtractionService
@@ -41,15 +41,9 @@ async def generate_presigned_url(
     service: UploadService = Depends(get_upload_service),
 ):
     """署名付きURLを生成して返す"""
-    try:
-        check_usecase_permission(user, request.app_name, "viewer")
-        sub = get_cognito_sub(req)
-        return await service.generate_presigned_url(request, uploaded_by=sub)
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error generating presigned URL: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    check_usecase_permission(user, request.app_name, "viewer")
+    sub = get_cognito_sub(req)
+    return await service.generate_presigned_url(request, uploaded_by=sub)
 
 
 @router.get("")
@@ -59,15 +53,11 @@ async def list_images(
     service: ImageListService = Depends(get_image_list_service),
 ):
     """画像一覧を取得する"""
-    try:
-        return await service.get_images_for_user(
-            user_id=str(user["id"]),
-            role=user["role"],
-            app_name=app_name,
-        )
-    except Exception as e:
-        logger.error(f"Error getting images: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    return await service.get_images_for_user(
+        user_id=str(user["id"]),
+        role=user["role"],
+        app_name=app_name,
+    )
 
 
 @router.delete("/{image_id}")
@@ -78,19 +68,9 @@ async def delete_image(
     service: ImageListService = Depends(get_image_list_service),
 ):
     """画像を削除する"""
-    try:
-        sub = get_cognito_sub(req)
-        is_admin = user.get("role") == "admin"
-        return await service.delete_image(image_id, sub, is_admin)
-    except HTTPException:
-        raise
-    except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except PermissionError as e:
-        raise HTTPException(status_code=403, detail=str(e))
-    except Exception as e:
-        logger.error(f"Error deleting image: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    sub = get_cognito_sub(req)
+    is_admin = user.get("role") == "admin"
+    return await service.delete_image(image_id, sub, is_admin)
 
 
 @router.get("/{image_id}/download-url")
@@ -100,11 +80,7 @@ async def generate_presigned_download_url(
     service: UploadService = Depends(get_upload_service),
 ):
     """ダウンロード用の署名付きURLを生成する"""
-    try:
-        return await service.generate_download_url(image_id)
-    except Exception as e:
-        logger.error(f"Error generating download URL: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    return await service.generate_download_url(image_id)
 
 
 @router.post("/{image_id}/upload-complete")
@@ -115,11 +91,7 @@ async def upload_complete(
     service: UploadService = Depends(get_upload_service),
 ):
     """アップロード完了を処理する"""
-    try:
-        return await service.handle_upload_complete(image_id, request)
-    except Exception as e:
-        logger.error(f"Error handling upload complete: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    return await service.handle_upload_complete(image_id, request)
 
 
 # === Process (Pipeline) ===
@@ -132,19 +104,8 @@ async def process_image(
     service: OcrService = Depends(get_ocr_service),
 ):
     """パイプライン実行（OCR→抽出→Agent）。body.skip_ocr=true で OCR をスキップし抽出以降のみ"""
-    try:
-        result = await service.start_step_functions_for_image(image_id, body.skip_ocr)
-        return result
-    except EndpointNotReadyError as e:
-        raise HTTPException(
-            status_code=503,
-            detail={"error": "endpoint_not_ready", "message": str(e)}
-        )
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"Error processing image: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    result = await service.start_step_functions_for_image(image_id, body.skip_ocr)
+    return result
 
 
 # === Status ===
@@ -155,20 +116,14 @@ async def get_image_status(
     user=Depends(RequireImagePermission("viewer")),
 ):
     """全フェーズのステータスを一括取得（ポーリング用）"""
-    try:
-        image_data = get_image(image_id)
-        if not image_data:
-            raise HTTPException(status_code=404, detail="Image not found")
-        return {
-            "extraction_status": image_data.get("status") or "not_started",
-            "agent_status": image_data.get("agent_status") or "idle",
-            "agent_pending_suggestions_count": image_data.get("agent_suggestions_count", 0),
-        }
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error getting image status: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    image_data = get_image(image_id)
+    if not image_data:
+        raise HTTPException(status_code=404, detail="Image not found")
+    return {
+        "extraction_status": image_data.get("status") or "not_started",
+        "agent_status": image_data.get("agent_status") or "idle",
+        "agent_pending_suggestions_count": image_data.get("agent_suggestions_count", 0),
+    }
 
 
 # === OCR ===
@@ -180,11 +135,7 @@ async def get_ocr_result(
     service: OcrService = Depends(get_ocr_service),
 ):
     """OCR結果を取得する"""
-    try:
-        return await service.get_ocr_result(image_id)
-    except Exception as e:
-        logger.error(f"Error getting OCR result: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    return await service.get_ocr_result(image_id)
 
 
 @router.put("/{image_id}/ocr")
@@ -195,12 +146,8 @@ async def update_ocr_result(
     service: OcrService = Depends(get_ocr_service),
 ):
     """OCR結果を更新する"""
-    try:
-        await service.update_ocr_result(image_id, edited_ocr_data)
-        return {"status": "success", "message": "OCR results updated successfully"}
-    except Exception as e:
-        logger.error(f"Error updating OCR result: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    await service.update_ocr_result(image_id, edited_ocr_data)
+    return {"status": "success", "message": "OCR results updated successfully"}
 
 
 # === Extraction ===
@@ -212,11 +159,7 @@ async def get_extraction_result(
     service: ExtractionService = Depends(get_extraction_service),
 ):
     """情報抽出結果を取得する"""
-    try:
-        return await service.get_extraction_result(image_id)
-    except Exception as e:
-        logger.error(f"Error getting extraction result: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    return await service.get_extraction_result(image_id)
 
 
 @router.put("/{image_id}/extraction")
@@ -227,12 +170,8 @@ async def update_extraction_result(
     service: ExtractionService = Depends(get_extraction_service),
 ):
     """情報抽出結果を更新する"""
-    try:
-        await service.update_extraction_result(image_id, edited_data)
-        return {"status": "success", "message": "Extraction results updated successfully"}
-    except Exception as e:
-        logger.error(f"Error updating extraction result: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    await service.update_extraction_result(image_id, edited_data)
+    return {"status": "success", "message": "Extraction results updated successfully"}
 
 
 # === Verification ===
@@ -246,12 +185,8 @@ async def update_verification_status(
     service: ExtractionService = Depends(get_extraction_service),
 ):
     """確認完了ステータスを更新する"""
-    try:
-        verified_by = get_cognito_sub(req)
-        return await service.update_verification_status(image_id, body.verification_completed, verified_by=verified_by)
-    except Exception as e:
-        logger.error(f"Error updating verification status: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    verified_by = get_cognito_sub(req)
+    return await service.update_verification_status(image_id, body.verification_completed, verified_by=verified_by)
 
 
 # === Agent ===
@@ -263,12 +198,8 @@ async def start_agent_correction(
     service: AgentService = Depends(get_agent_service),
 ):
     """Agent検証を開始する"""
-    try:
-        job_id = await service.start_agent_correction(image_id)
-        return {"jobId": job_id}
-    except Exception as e:
-        logger.error(f"Error starting agent correction: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    job_id = await service.start_agent_correction(image_id)
+    return {"jobId": job_id}
 
 
 @router.get("/{image_id}/agent")
@@ -277,35 +208,31 @@ async def get_agent_job_by_image(
     user=Depends(RequireImagePermission("viewer")),
 ):
     """画像の最新エージェントジョブを取得"""
-    try:
-        image = get_image(image_id)
-        image_agent_status = image.get("agent_status") if image else None
+    image = get_image(image_id)
+    image_agent_status = image.get("agent_status") if image else None
 
-        job = get_latest_agent_job_by_image_id(image_id)
-        if not job:
-            if image_agent_status == "processing":
-                return {"status": "processing", "suggestions": []}
-            return {"status": "none", "suggestions": []}
-
-        job_status = job.get("status")
-        if image_agent_status == "processing" and job_status not in ("processing",):
+    job = get_latest_agent_job_by_image_id(image_id)
+    if not job:
+        if image_agent_status == "processing":
             return {"status": "processing", "suggestions": []}
+        return {"status": "none", "suggestions": []}
 
-        suggestions = job.get("suggestions", [])
-        pending = []
-        for i, s in enumerate(suggestions):
-            if s.get("status", SuggestionStatus.PENDING) == SuggestionStatus.PENDING:
-                pending.append({**s, "index": i})
-        return {
-            "job_id": job.get("id"),
-            "status": job_status,
-            "suggestions": pending,
-            "total_suggestions_count": len(suggestions),
-            "error": job.get("error"),
-        }
-    except Exception as e:
-        logger.error(f"Error getting agent job by image: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    job_status = job.get("status")
+    if image_agent_status == "processing" and job_status not in ("processing",):
+        return {"status": "processing", "suggestions": []}
+
+    suggestions = job.get("suggestions", [])
+    pending = []
+    for i, s in enumerate(suggestions):
+        if s.get("status", SuggestionStatus.PENDING) == SuggestionStatus.PENDING:
+            pending.append({**s, "index": i})
+    return {
+        "job_id": job.get("id"),
+        "status": job_status,
+        "suggestions": pending,
+        "total_suggestions_count": len(suggestions),
+        "error": job.get("error"),
+    }
 
 
 @router.get("/{image_id}/agent/tools")
@@ -315,11 +242,7 @@ async def get_agent_tools_for_image(
     service: AgentService = Depends(get_agent_service),
 ):
     """画像のユースケースに紐づくツール一覧"""
-    try:
-        return await service.get_usecase_tools_for_image(image_id)
-    except Exception as e:
-        logger.error(f"Error getting tools: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    return await service.get_usecase_tools_for_image(image_id)
 
 
 @router.patch("/{image_id}/agent/suggestions/{suggestion_index}")
@@ -330,11 +253,5 @@ async def update_suggestion(
     user=Depends(RequireImagePermission("viewer")),
 ):
     """提案の採用/却下を永続化"""
-    try:
-        pending_count = update_suggestion_status(image_id, suggestion_index, body.status)
-        return {"ok": True, "pending_count": pending_count}
-    except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        logger.error(f"Error updating suggestion: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    pending_count = update_suggestion_status(image_id, suggestion_index, body.status)
+    return {"ok": True, "pending_count": pending_count}

--- a/lambda/api/app/routers/jobs.py
+++ b/lambda/api/app/routers/jobs.py
@@ -22,21 +22,13 @@ async def get_job_status(
     service: AgentService = Depends(get_agent_service),
 ):
     """ジョブステータスを取得する"""
-    try:
-        job = get_job(job_id)
-        if not job:
-            raise HTTPException(status_code=404, detail="Job not found")
+    job = get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
 
-        image = get_image(job.get("image_id", ""))
-        if not image:
-            raise HTTPException(status_code=404, detail="Associated image not found")
-        check_usecase_permission(user, image.get("app_name", ""), "viewer")
+    image = get_image(job.get("image_id", ""))
+    if not image:
+        raise HTTPException(status_code=404, detail="Associated image not found")
+    check_usecase_permission(user, image.get("app_name", ""), "viewer")
 
-        return await service.get_agent_job_status(job_id)
-    except HTTPException:
-        raise
-    except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        logger.error(f"Error getting job status: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    return await service.get_agent_job_status(job_id)

--- a/lambda/api/app/routers/sharing.py
+++ b/lambda/api/app/routers/sharing.py
@@ -1,10 +1,10 @@
 """共有設定 API"""
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, Depends
 import logging
 
 from dependencies.auth import RequirePermission
 from schemas.sharing import ShareUserRequest, ShareGroupRequest
-from services.sharing_service import SharingService, LastOwnerError
+from services.sharing_service import SharingService
 from dependencies.services import get_sharing_service
 
 logger = logging.getLogger(__name__)
@@ -14,59 +14,39 @@ router = APIRouter(prefix="/apps/{app_name}/sharing", tags=["Sharing"])
 @router.get("")
 async def get_sharing(app_name: str, user=Depends(RequirePermission("viewer")), service: SharingService = Depends(get_sharing_service)):
     """共有情報を取得（viewer 以上）"""
-    try:
-        return service.get_sharing(app_name)
-    except ValueError as e:
-        raise HTTPException(404, str(e))
+    return service.get_sharing(app_name)
 
 
 @router.post("/users")
 async def add_user_sharing(app_name: str, body: ShareUserRequest, user=Depends(RequirePermission("owner")), service: SharingService = Depends(get_sharing_service)):
     """ユーザーに権限を付与（owner 以上）"""
-    try:
-        service.add_user_sharing(app_name, body.user_id, body.permission)
-        return {"ok": True}
-    except ValueError as e:
-        raise HTTPException(404, str(e))
+    service.add_user_sharing(app_name, body.user_id, body.permission)
+    return {"ok": True}
 
 
 @router.delete("/users/{user_id}")
 async def remove_user_sharing(app_name: str, user_id: str, user=Depends(RequirePermission("owner")), service: SharingService = Depends(get_sharing_service)):
     """ユーザーの権限を削除（owner 以上）"""
-    try:
-        service.remove_user_sharing(app_name, user_id)
-        return {"ok": True}
-    except LastOwnerError as e:
-        raise HTTPException(400, str(e))
-    except ValueError as e:
-        raise HTTPException(404, str(e))
+    service.remove_user_sharing(app_name, user_id)
+    return {"ok": True}
 
 
 @router.post("/groups")
 async def add_group_sharing(app_name: str, body: ShareGroupRequest, user=Depends(RequirePermission("owner")), service: SharingService = Depends(get_sharing_service)):
     """グループに権限を付与（owner 以上）"""
-    try:
-        service.add_group_sharing(app_name, body.group_id, body.permission)
-        return {"ok": True}
-    except ValueError as e:
-        raise HTTPException(404, str(e))
+    service.add_group_sharing(app_name, body.group_id, body.permission)
+    return {"ok": True}
 
 
 @router.delete("/groups/{group_id}")
 async def remove_group_sharing(app_name: str, group_id: str, user=Depends(RequirePermission("owner")), service: SharingService = Depends(get_sharing_service)):
     """グループの権限を削除（owner 以上）"""
-    try:
-        service.remove_group_sharing(app_name, group_id)
-        return {"ok": True}
-    except ValueError as e:
-        raise HTTPException(404, str(e))
+    service.remove_group_sharing(app_name, group_id)
+    return {"ok": True}
 
 
 @router.post("/all")
 async def share_with_all(app_name: str, user=Depends(RequirePermission("owner")), service: SharingService = Depends(get_sharing_service)):
     """全ユーザー（all グループ）に共有（owner 以上）"""
-    try:
-        service.share_with_all(app_name)
-        return {"ok": True}
-    except ValueError as e:
-        raise HTTPException(404, str(e))
+    service.share_with_all(app_name)
+    return {"ok": True}

--- a/lambda/api/app/routers/system.py
+++ b/lambda/api/app/routers/system.py
@@ -2,7 +2,7 @@
 
 Infrastructure status endpoints (no auth required).
 """
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, Depends
 import logging
 
 from services.ocr_service import OcrService
@@ -17,8 +17,4 @@ async def get_ocr_endpoint_status(
     service: OcrService = Depends(get_ocr_service),
 ):
     """OCRエンドポイントの状態を確認（ポーリング用、認証不要）"""
-    try:
-        return service.get_endpoint_status()
-    except Exception as e:
-        logger.error(f"Error checking endpoint status: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    return service.get_endpoint_status()

--- a/lambda/api/app/routers/tools.py
+++ b/lambda/api/app/routers/tools.py
@@ -2,7 +2,7 @@
 
 Global tool listing.
 """
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, Depends
 import logging
 
 from services.agent_service import AgentService
@@ -19,8 +19,4 @@ async def get_all_tools(
     service: AgentService = Depends(get_agent_service),
 ):
     """全ツール一覧を取得する"""
-    try:
-        return await service.get_available_tools()
-    except Exception as e:
-        logger.error(f"Error getting tools: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+    return await service.get_available_tools()

--- a/lambda/api/app/services/admin_service.py
+++ b/lambda/api/app/services/admin_service.py
@@ -1,14 +1,10 @@
 """管理者操作サービス"""
 import logging
 
+from exceptions import NotFoundError, BadRequestError
 from repositories import user_repository, group_repository, usecase_repository, tool_repository
 
 logger = logging.getLogger(__name__)
-
-
-class NotFoundError(Exception):
-    """リソースが見つからない場合のエラー"""
-    pass
 
 
 class AdminService:
@@ -45,18 +41,18 @@ class AdminService:
         """グループを削除する（auto グループは削除不可）"""
         group = group_repository.get_group(group_id)
         if not group:
-            raise NotFoundError("Group not found")
+            raise NotFoundError("グループが見つかりません")
         if group["source"] == "auto":
-            raise ValueError("Cannot delete auto-managed group")
+            raise BadRequestError("自動管理グループは削除できません")
         group_repository.delete_group(group_id)
 
     def update_group(self, group_id: str, name: str = None, description: str = None) -> bool:
         """グループの名前・説明を更新する（auto グループは編集不可）"""
         group = group_repository.get_group(group_id)
         if not group:
-            raise NotFoundError("Group not found")
+            raise NotFoundError("グループが見つかりません")
         if group["source"] == "auto":
-            raise ValueError("Cannot edit auto-managed group")
+            raise BadRequestError("自動管理グループは編集できません")
         return group_repository.update_group(group_id, name=name, description=description)
 
     def update_group_members(self, group_id: str, user_ids: list[str]) -> None:
@@ -70,7 +66,7 @@ class AdminService:
         """app_name から usecase_id を解決する"""
         usecase = usecase_repository.get_usecase_by_app_name(app_name)
         if not usecase:
-            raise NotFoundError(f"Usecase not found for app_name: {app_name}")
+            raise NotFoundError(f"ユースケースが見つかりません: {app_name}")
         return str(usecase["id"])
 
     def get_usecase_permissions(self, app_name: str) -> dict:

--- a/lambda/api/app/services/agent_service.py
+++ b/lambda/api/app/services/agent_service.py
@@ -4,6 +4,7 @@ import base64
 import json
 import logging
 from domains.image_status import AgentStatus
+from exceptions import NotFoundError
 from repositories.job_repository import JobStatus, SuggestionStatus
 from typing import Dict, Any
 
@@ -68,7 +69,7 @@ class AgentService:
             # Get OCR extraction results
             image_data = get_image(image_id)
             if not image_data:
-                raise ValueError(f"Image not found: {image_id}")
+                raise NotFoundError(f"画像が見つかりません: {image_id}")
 
             extracted_info = image_data.get("extracted_info", {})
             if not extracted_info:
@@ -129,7 +130,7 @@ class AgentService:
         """
         job = get_job(job_id)
         if not job:
-            raise ValueError(f"Job not found: {job_id}")
+            raise NotFoundError(f"ジョブが見つかりません: {job_id}")
 
         suggestions = job.get("suggestions", [])
         pending = []

--- a/lambda/api/app/services/extraction_service.py
+++ b/lambda/api/app/services/extraction_service.py
@@ -9,6 +9,7 @@ from repositories import (
     get_app_display_name, update_verification_status
 )
 from config import settings
+from exceptions import NotFoundError
 from background import BackgroundTaskExtension
 from utils import decimal_to_float
 from utils.bedrock import parse_converse_response, extract_json_from_response
@@ -81,12 +82,12 @@ class InformationExtractor(ABC):
             if not image_data:
                 logger.error(f"画像 {self.image_id} が見つかりません")
                 update_image_status(self.image_id, ImageStatus.FAILED)
-                raise ValueError(f"画像 {self.image_id} が見つかりません")
+                raise NotFoundError(f"画像 {self.image_id} が見つかりません")
 
             app_name = image_data.get("app_name")
             if not app_name:
                 logger.error(f"app_name not found for image {self.image_id}")
-                raise ValueError(f"app_name not found for image {self.image_id}")
+                raise NotFoundError(f"app_name not found for image {self.image_id}")
 
             update_image_status(self.image_id, ImageStatus.EXTRACTING)
 
@@ -168,7 +169,7 @@ class MultiImageExtractor(InformationExtractor):
     def _fetch_images(self, image_data: dict) -> tuple:
         converted_s3_keys = image_data.get("converted_s3_key", [])
         if not converted_s3_keys:
-            raise ValueError("変換済み画像が見つかりません")
+            raise NotFoundError("変換済み画像が見つかりません")
         if not isinstance(converted_s3_keys, list):
             converted_s3_keys = [converted_s3_keys]
 
@@ -186,13 +187,13 @@ class MultiImageExtractor(InformationExtractor):
                 continue
 
         if not page_images:
-            raise ValueError("画像データを取得できませんでした")
+            raise NotFoundError("画像データを取得できませんでした")
         return page_images, content_type
 
     def _get_ocr_data(self, image_data: dict):
         ocr_results = get_multipage_ocr_results(self.image_id)
         if not ocr_results:
-            raise ValueError("OCR結果が見つかりません")
+            raise NotFoundError("OCR結果が見つかりません")
         return ocr_results
 
     def _build_ocr_request(self, images, content_type, ocr_data, fields, custom_prompt) -> tuple:
@@ -223,11 +224,11 @@ class SingleImageExtractor(InformationExtractor):
     def _fetch_images(self, image_data: dict) -> tuple:
         converted_s3_keys = image_data.get("converted_s3_key", [])
         if not converted_s3_keys:
-            raise ValueError("変換済み画像が見つかりません")
+            raise NotFoundError("変換済み画像が見つかりません")
 
         s3_key = converted_s3_keys[0] if isinstance(converted_s3_keys, list) else converted_s3_keys
         if not s3_key:
-            raise ValueError("有効なS3キーが見つかりません")
+            raise NotFoundError("有効なS3キーが見つかりません")
 
         s3_response = s3_client.get_object(Bucket=settings.BUCKET_NAME, Key=s3_key)
         image_bytes = s3_response['Body'].read()
@@ -273,12 +274,12 @@ class ExtractionService:
 
             if not image_data:
                 logger.warning(f"画像が見つかりません (image_id: {image_id})")
-                raise ValueError("画像が見つかりません")
+                raise NotFoundError("画像が見つかりません")
 
             app_name = image_data.get("app_name")
             if not app_name:
                 logger.error(f"app_name not found for image {image_id}")
-                raise ValueError(f"app_name not found for image {image_id}")
+                raise NotFoundError(f"画像のアプリ名が取得できません: {image_id}")
 
             app_display_name = get_app_display_name(app_name)
             # snapshot 側と型を揃えて比較・返却するため現スキーマも Decimal→float 正規化する
@@ -362,7 +363,7 @@ class ExtractionService:
 
             image_data = get_image(image_id)
             if not image_data:
-                raise ValueError(f"Image not found: {image_id}")
+                raise NotFoundError(f"Image not found: {image_id}")
 
             extractor = self._get_extractor(image_id, image_data)
             extractor.extract()

--- a/lambda/api/app/services/extraction_service.py
+++ b/lambda/api/app/services/extraction_service.py
@@ -87,7 +87,7 @@ class InformationExtractor(ABC):
             app_name = image_data.get("app_name")
             if not app_name:
                 logger.error(f"app_name not found for image {self.image_id}")
-                raise NotFoundError(f"app_name not found for image {self.image_id}")
+                raise NotFoundError(f"画像のアプリ名が取得できません: {self.image_id}")
 
             update_image_status(self.image_id, ImageStatus.EXTRACTING)
 
@@ -363,7 +363,7 @@ class ExtractionService:
 
             image_data = get_image(image_id)
             if not image_data:
-                raise NotFoundError(f"Image not found: {image_id}")
+                raise NotFoundError(f"画像が見つかりません: {image_id}")
 
             extractor = self._get_extractor(image_id, image_data)
             extractor.extract()

--- a/lambda/api/app/services/image_list_service.py
+++ b/lambda/api/app/services/image_list_service.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Dict, Any
 
+from exceptions import NotFoundError, ForbiddenError
 from repositories import (
     get_image, get_images,
     get_children_by_parent_id, delete_image as repo_delete_image
@@ -109,11 +110,11 @@ class ImageListService:
         try:
             image = get_image(image_id)
             if not image:
-                raise ValueError("Image not found")
+                raise NotFoundError("画像が見つかりません")
 
             if not is_admin:
                 if not cognito_sub or image.get("uploaded_by") != cognito_sub:
-                    raise PermissionError("Forbidden: not the owner")
+                    raise ForbiddenError("この操作を行う権限がありません")
 
             parent_document_id = image.get("parent_document_id")
             page_processing_mode = image.get("page_processing_mode")

--- a/lambda/api/app/services/ocr_service.py
+++ b/lambda/api/app/services/ocr_service.py
@@ -4,6 +4,7 @@ import json
 import base64
 from typing import Dict, Any
 
+from exceptions import EndpointNotReadyError, NotFoundError, BadRequestError
 from repositories import (
     get_images,
     get_image, update_ocr_result as db_update_ocr_result,
@@ -38,11 +39,6 @@ def _guess_image_content_type(image_data: bytes) -> str:
     return "image/jpeg"
 
 
-class EndpointNotReadyError(Exception):
-    """OCR エンドポイントが起動中の場合のエラー"""
-    pass
-
-
 class OcrService:
     """OCR処理を管理するサービスクラス"""
 
@@ -60,9 +56,9 @@ class OcrService:
     def _invoke_ocr(self, image_data: bytes) -> dict:
         """SageMaker OCR エンドポイントを呼び出し、整形済み結果を返す"""
         if not self.enable_ocr:
-            raise ValueError("OCR is disabled in this deployment")
+            raise BadRequestError("この環境では OCR が無効です")
         if not settings.SAGEMAKER_ENDPOINT_NAME:
-            raise ValueError("SageMaker endpoint not configured")
+            raise RuntimeError("SageMaker endpoint not configured")
 
         if settings.OCR_ENGINE == "yomitoku-mp":
             return self._invoke_yomitoku_mp(image_data)
@@ -102,7 +98,7 @@ class OcrService:
         """OCR結果を取得する"""
         image_data = get_image(image_id)
         if not image_data:
-            raise ValueError("Image not found")
+            raise NotFoundError("画像が見つかりません")
 
         ocr_result = image_data.get("ocr_result", {})
         # OCR無効時はocr_resultが存在しない
@@ -134,7 +130,7 @@ class OcrService:
             logger.info(f"Processing single image: {image_id}")
             image_data = get_image(image_id)
             if not image_data:
-                raise ValueError(f"Image not found: {image_id}")
+                raise NotFoundError(f"画像が見つかりません: {image_id}")
 
             update_image_status(image_id, ImageStatus.OCR)
             sync_parent_status(image_id)
@@ -175,7 +171,7 @@ class OcrService:
 
         converted_s3_keys = image_data.get("converted_s3_key")
         if not converted_s3_keys or not isinstance(converted_s3_keys, list):
-            raise ValueError("複数ページの変換済み画像が見つかりません")
+            raise NotFoundError("複数ページの変換済み画像が見つかりません")
 
         ocr_results = []
         for i, s3_key in enumerate(converted_s3_keys):
@@ -185,7 +181,7 @@ class OcrService:
                 image_bytes = s3_response['Body'].read()
                 ocr_result = self._invoke_ocr(image_bytes)
                 if "error" in ocr_result:
-                    raise ValueError(f"OCR処理エラー: {ocr_result['error']}")
+                    raise RuntimeError(f"OCR処理エラー: {ocr_result['error']}")
                 page_result = {
                     "page": i + 1,
                     "words": ocr_result.get("words", []),
@@ -289,7 +285,7 @@ class OcrService:
                 if not status['ready']:
                     if settings.OCR_ENGINE != "yomitoku-mp":
                         trigger_endpoint_wakeup(settings.SAGEMAKER_ENDPOINT_NAME, settings.SAGEMAKER_INFERENCE_COMPONENT_NAME)
-                    raise EndpointNotReadyError('Endpoint warming up')
+                    raise EndpointNotReadyError('OCR エンドポイントが起動中です。しばらくお待ちください。')
 
             job_id = str(uuid.uuid4())
             app_name = request.app_name
@@ -353,7 +349,7 @@ class OcrService:
                 if not status['ready']:
                     if settings.OCR_ENGINE != "yomitoku-mp":
                         trigger_endpoint_wakeup(settings.SAGEMAKER_ENDPOINT_NAME, settings.SAGEMAKER_INFERENCE_COMPONENT_NAME)
-                    raise EndpointNotReadyError('Endpoint warming up')
+                    raise EndpointNotReadyError('OCR エンドポイントが起動中です。しばらくお待ちください。')
 
             job_id = str(uuid.uuid4())
 

--- a/lambda/api/app/services/pdf_conversion_service.py
+++ b/lambda/api/app/services/pdf_conversion_service.py
@@ -35,10 +35,10 @@ def convert_pdf_to_image(image_id: str, s3_key: str):
 
         image_data = get_image(image_id)
         if not image_data:
-            raise NotFoundError(f"Image not found: {image_id}")
+            raise NotFoundError(f"画像が見つかりません: {image_id}")
         app_name = image_data.get("app_name")
         if not app_name:
-            raise NotFoundError(f"app_name not found for image {image_id}")
+            raise NotFoundError(f"画像のアプリ名が取得できません: {image_id}")
 
         processing_mode = image_data.get("page_processing_mode", PageProcessingMode.COMBINED)
         input_methods = get_app_input_methods(app_name)
@@ -63,7 +63,7 @@ def convert_pdf_to_image(image_id: str, s3_key: str):
         try:
             pdf_document = fitz.open(temp_pdf_path)
             if pdf_document.page_count == 0:
-                raise BadRequestError("PDF has no pages")
+                raise BadRequestError("PDF にページがありません")
 
             upload_bucket = settings.BUCKET_NAME
             if not upload_bucket:
@@ -124,7 +124,7 @@ def _process_combined_pages(pdf_document, image_id: str, s3_key: str, upload_buc
     logger.info(f"複数画像処理を開始: {total_pages}ページ")
 
     if total_pages > 10:
-        raise BadRequestError(f"PDF has too many pages ({total_pages}). Maximum supported: 10")
+        raise BadRequestError(f"PDF のページ数が多すぎます（{total_pages}）。最大 10 ページまでです")
 
     if total_pages == 1:
         return _process_single_page_combined(pdf_document, image_id, s3_key, upload_bucket)

--- a/lambda/api/app/services/pdf_conversion_service.py
+++ b/lambda/api/app/services/pdf_conversion_service.py
@@ -15,6 +15,7 @@ import io
 
 from clients import s3_client
 from config import settings
+from exceptions import NotFoundError, BadRequestError
 from repositories import (
     get_image, update_image_status, update_converted_image,
     update_ocr_result, update_parent_document_status,
@@ -34,10 +35,10 @@ def convert_pdf_to_image(image_id: str, s3_key: str):
 
         image_data = get_image(image_id)
         if not image_data:
-            raise ValueError(f"Image not found: {image_id}")
+            raise NotFoundError(f"Image not found: {image_id}")
         app_name = image_data.get("app_name")
         if not app_name:
-            raise ValueError(f"app_name not found for image {image_id}")
+            raise NotFoundError(f"app_name not found for image {image_id}")
 
         processing_mode = image_data.get("page_processing_mode", PageProcessingMode.COMBINED)
         input_methods = get_app_input_methods(app_name)
@@ -62,11 +63,11 @@ def convert_pdf_to_image(image_id: str, s3_key: str):
         try:
             pdf_document = fitz.open(temp_pdf_path)
             if pdf_document.page_count == 0:
-                raise ValueError("PDF has no pages")
+                raise BadRequestError("PDF has no pages")
 
             upload_bucket = settings.BUCKET_NAME
             if not upload_bucket:
-                raise ValueError("BUCKET_NAME environment variable is not set")
+                raise RuntimeError("BUCKET_NAME environment variable is not set")
 
             if processing_mode == PageProcessingMode.COMBINED:
                 _process_combined_pages(pdf_document, image_id, s3_key, upload_bucket)
@@ -123,7 +124,7 @@ def _process_combined_pages(pdf_document, image_id: str, s3_key: str, upload_buc
     logger.info(f"複数画像処理を開始: {total_pages}ページ")
 
     if total_pages > 10:
-        raise ValueError(f"PDF has too many pages ({total_pages}). Maximum supported: 10")
+        raise BadRequestError(f"PDF has too many pages ({total_pages}). Maximum supported: 10")
 
     if total_pages == 1:
         return _process_single_page_combined(pdf_document, image_id, s3_key, upload_bucket)

--- a/lambda/api/app/services/s3_sync_service.py
+++ b/lambda/api/app/services/s3_sync_service.py
@@ -6,6 +6,7 @@ from typing import Dict, Any, Optional, List
 from botocore.exceptions import ClientError
 
 from config import settings
+from exceptions import NotFoundError, BadRequestError, ConflictError
 from domains.image_status import ImageStatus, PageProcessingMode
 from repositories.schema_repository import get_app_schema
 from repositories.image_repository import create_image_record, get_images_by_sync_source, get_existing_sync_sources
@@ -29,13 +30,13 @@ class S3SyncService:
             # アプリケーションの入力方法設定を取得
             app_schema = get_app_schema(app_name)
             if not app_schema:
-                raise ValueError(f"アプリが見つかりません: {app_name}")
+                raise NotFoundError(f"アプリが見つかりません: {app_name}")
 
             input_methods = app_schema.get("input_methods", {})
 
             # S3同期が有効かチェック
             if not input_methods.get("s3_sync", False):
-                raise ValueError(f"S3同期はこのアプリケーションでは有効になっていません: {app_name}")
+                raise BadRequestError(f"S3同期はこのアプリケーションでは有効になっていません: {app_name}")
 
             # 同期バケットからファイル一覧を取得
             s3_path = f"{app_name}/"
@@ -66,13 +67,13 @@ class S3SyncService:
             # アプリケーションの入力方法設定を取得
             app_schema = get_app_schema(app_name)
             if not app_schema:
-                raise ValueError(f"アプリが見つかりません: {app_name}")
+                raise NotFoundError(f"アプリが見つかりません: {app_name}")
 
             input_methods = app_schema.get("input_methods", {})
 
             # S3同期が有効かチェック
             if not input_methods.get("s3_sync", False):
-                raise ValueError(f"S3同期はこのアプリケーションでは有効になっていません: {app_name}")
+                raise BadRequestError(f"S3同期はこのアプリケーションでは有効になっていません: {app_name}")
 
             # ファイル情報を取得
             source_bucket = file_data.get("bucket")
@@ -81,15 +82,15 @@ class S3SyncService:
             page_processing_mode = file_data.get("page_processing_mode", PageProcessingMode.COMBINED)
 
             if not all([source_bucket, source_key, filename]):
-                raise ValueError("bucket, key, filename are required")
+                raise BadRequestError("bucket, key, filename は必須です")
 
             if source_bucket != self.sync_bucket_name:
-                raise ValueError("Invalid source bucket")
+                raise BadRequestError("無効なソースバケットです")
 
             # 重複チェック
             existing_files = get_images_by_sync_source(filename, source_key, app_name)
             if existing_files:
-                raise ValueError(f"ファイル '{filename}' は既にインポート済みです")
+                raise ConflictError(f"ファイル '{filename}' は既にインポート済みです")
 
             # 新しい画像IDを生成
             image_id = str(uuid.uuid4())
@@ -236,7 +237,7 @@ class S3SyncService:
 
         except ClientError as e:
             logger.error(f"Error listing S3 files: {str(e)}")
-            raise ValueError(f"S3バケットへのアクセスに失敗しました: {str(e)}")
+            raise RuntimeError(f"S3バケットへのアクセスに失敗しました: {str(e)}")
 
     async def _copy_s3_file(self, source_bucket: str, source_key: str, destination_key: str) -> None:
         """S3ファイルを自分のバケットにコピーする"""
@@ -256,4 +257,4 @@ class S3SyncService:
 
         except ClientError as e:
             logger.error(f"Error copying S3 file: {str(e)}")
-            raise ValueError(f"S3ファイルのコピーに失敗しました: {str(e)}")
+            raise RuntimeError(f"S3ファイルのコピーに失敗しました: {str(e)}")

--- a/lambda/api/app/services/schema_service.py
+++ b/lambda/api/app/services/schema_service.py
@@ -12,6 +12,7 @@ from schemas import (
     NAME_PATTERN,
 )
 from config import settings
+from exceptions import NotFoundError, BadRequestError
 from repositories import (
     get_app_schemas, get_app_schema, get_extraction_fields_for_app,
     get_custom_prompt_for_app, update_app_schema, create_app_schema,
@@ -98,7 +99,7 @@ class SchemaService:
             for app in app_schemas.get("apps", []):
                 if app["name"] == app_name:
                     return app
-            raise ValueError(f"App '{app_name}' not found")
+            raise NotFoundError(f"アプリが見つかりません: {app_name}")
         except Exception as e:
             logger.error(f"Error getting app details: {str(e)}")
             raise
@@ -133,7 +134,7 @@ class SchemaService:
             # 既存のアプリスキーマを取得
             app_schema = get_app_schema(app_name)
             if not app_schema:
-                raise ValueError(f"App '{app_name}' not found")
+                raise NotFoundError(f"アプリが見つかりません: {app_name}")
 
             # カスタムプロンプトを更新
             app_schema["custom_prompt"] = request.custom_prompt
@@ -168,15 +169,15 @@ class SchemaService:
         try:
             # 入力バリデーション
             if not request.name or not request.display_name:
-                raise ValueError("アプリ名と表示名は必須です")
+                raise BadRequestError("アプリ名と表示名は必須です")
 
             # アプリ名のバリデーション（英数字とアンダースコアのみ）
             if not NAME_PATTERN.match(request.name):
-                raise ValueError("アプリ名は英数字とアンダースコアのみ使用できます")
+                raise BadRequestError("アプリ名は英数字とアンダースコアのみ使用できます")
 
             # 入力方法のバリデーション
             if not request.input_methods.get("file_upload", False) and not request.input_methods.get("s3_sync", False):
-                raise ValueError("ファイルアップロードまたはS3同期のいずれかを有効にする必要があります")
+                raise BadRequestError("ファイルアップロードまたはS3同期のいずれかを有効にする必要があります")
 
             # スキーマデータを作成
             app_data = self._build_app_data(request)
@@ -214,7 +215,7 @@ class SchemaService:
         try:
             app_schema = get_app_schema(app_name)
             if not app_schema:
-                raise ValueError(f"App '{app_name}' not found")
+                raise NotFoundError(f"アプリが見つかりません: {app_name}")
 
             s3_key = app_schema.get("sample_image_s3_key")
             if not s3_key:
@@ -292,7 +293,7 @@ class SchemaService:
                 file_data = s3_response['Body'].read()
             except Exception as e:
                 logger.error(f"S3からのファイル取得エラー: {str(e)}")
-                raise ValueError("ファイルが見つかりません")
+                raise NotFoundError("ファイルが見つかりません")
 
             # ファイルの種類を拡張子で判定
             _, ext = os.path.splitext(request.filename)
@@ -305,9 +306,9 @@ class SchemaService:
                     logger.info(f"PDFを画像に変換しました: {request.filename}")
                 except Exception as e:
                     logger.error(f"PDF変換エラー: {str(e)}")
-                    raise ValueError("PDFの変換に失敗しました。有効なPDFファイルをアップロードしてください。")
+                    raise BadRequestError("PDFの変換に失敗しました。有効なPDFファイルをアップロードしてください。")
             elif ext not in ['.jpg', '.jpeg', '.png', '.gif']:
-                raise ValueError(
+                raise BadRequestError(
                     "サポートされていないファイル形式です。JPG、PNG、GIF、PDFのみ対応しています。")
 
             # スキーマフィールドを生成（build → Bedrock 呼び出し → parse）
@@ -343,7 +344,7 @@ class SchemaService:
         """
         try:
             if not settings.SCHEMA_GENERATE_FUNCTION_NAME:
-                raise ValueError("SCHEMA_GENERATE_FUNCTION_NAME is not configured")
+                raise RuntimeError("SCHEMA_GENERATE_FUNCTION_NAME is not configured")
 
             # 1. ジョブレコード作成
             job_id = create_schema_generation_job(
@@ -384,10 +385,10 @@ class SchemaService:
         """
         job = get_job(job_id)
         if not job:
-            raise ValueError(f"Job not found: {job_id}")
+            raise NotFoundError(f"ジョブが見つかりません: {job_id}")
 
         if job.get("job_type") != JobType.SCHEMA_GENERATION:
-            raise ValueError(f"Job {job_id} is not a schema_generation job")
+            raise BadRequestError(f"ジョブ {job_id} はスキーマ生成ジョブではありません")
 
         return {
             "status": job.get("status", "processing"),
@@ -400,15 +401,15 @@ class SchemaService:
         try:
             # 入力バリデーション
             if not request.name or not request.display_name:
-                raise ValueError("アプリ名と表示名は必須です")
+                raise BadRequestError("アプリ名と表示名は必須です")
 
             # アプリ名のバリデーション（英数字とアンダースコアのみ）
             if not NAME_PATTERN.match(request.name):
-                raise ValueError("アプリ名は英数字とアンダースコアのみ使用できます")
+                raise BadRequestError("アプリ名は英数字とアンダースコアのみ使用できます")
 
             # 入力方法のバリデーション
             if not request.input_methods.get("file_upload", False) and not request.input_methods.get("s3_sync", False):
-                raise ValueError("ファイルアップロードまたはS3同期のいずれかを有効にする必要があります")
+                raise BadRequestError("ファイルアップロードまたはS3同期のいずれかを有効にする必要があります")
 
             # スキーマデータを作成
             app_data = self._build_app_data(request)

--- a/lambda/api/app/services/sharing_service.py
+++ b/lambda/api/app/services/sharing_service.py
@@ -1,14 +1,10 @@
 """共有設定サービス"""
 import logging
 
+from exceptions import LastOwnerError, NotFoundError
 from repositories import usecase_repository, group_repository
 
 logger = logging.getLogger(__name__)
-
-
-class LastOwnerError(Exception):
-    """最後のオーナーを削除しようとした場合のエラー"""
-    pass
 
 
 class SharingService:
@@ -18,7 +14,7 @@ class SharingService:
     def _get_usecase_id(self, app_name: str) -> str:
         uc = usecase_repository.get_usecase_by_app_name(app_name)
         if not uc:
-            raise ValueError("Usecase not found")
+            raise NotFoundError("ユースケースが見つかりません")
         return str(uc["id"])
 
     def get_sharing(self, app_name: str) -> dict:
@@ -36,7 +32,7 @@ class SharingService:
         uc_id = self._get_usecase_id(app_name)
         deleted = usecase_repository.delete_user_permission_safe(user_id, uc_id)
         if not deleted:
-            raise LastOwnerError("Cannot remove the last owner")
+            raise LastOwnerError("最後のオーナーは削除できません")
 
     def add_group_sharing(self, app_name: str, group_id: str, permission: str) -> None:
         uc_id = self._get_usecase_id(app_name)
@@ -50,5 +46,5 @@ class SharingService:
         uc_id = self._get_usecase_id(app_name)
         all_group = group_repository.get_group_by_name("all")
         if not all_group:
-            raise ValueError("all group not found")
+            raise NotFoundError("all グループが見つかりません")
         usecase_repository.upsert_group_permission(str(all_group["id"]), uc_id, "viewer")

--- a/lambda/api/app/services/upload_service.py
+++ b/lambda/api/app/services/upload_service.py
@@ -4,6 +4,7 @@ import logging
 from datetime import datetime
 from typing import Dict, Any, Optional
 
+from exceptions import NotFoundError, BadRequestError
 from repositories import (
     create_image_record, get_image, update_image_status, update_converted_image,
 )
@@ -40,14 +41,14 @@ class UploadService:
 
             if not valid_app:
                 logger.error(f"Invalid app name: {request.app_name}")
-                raise ValueError(f"Invalid app name: {request.app_name}")
+                raise BadRequestError(f"無効なアプリ名です: {request.app_name}")
 
             # アプリケーションの入力方法設定を取得
             input_methods = get_app_input_methods(request.app_name)
 
             # ファイルアップロードが有効かチェック
             if not input_methods.get("file_upload", True):
-                raise ValueError(
+                raise BadRequestError(
                     f"ファイルアップロードはこのアプリケーションでは無効です: {request.app_name}")
 
             # 一意のS3キーを生成
@@ -102,7 +103,7 @@ class UploadService:
                     'ContentType', 'application/octet-stream')
             except Exception as e:
                 logger.error(f"S3 object not found: {str(e)}")
-                raise ValueError("File not found in S3")
+                raise NotFoundError("S3 にファイルが見つかりません")
 
             # ファイル種別を判定
             is_image = content_type.startswith('image/')
@@ -187,7 +188,7 @@ class UploadService:
 
             # バックグラウンドタスクとして変換処理を実行
             if not self.background_task:
-                raise ValueError("background_task is not configured for PDF conversion")
+                raise RuntimeError("background_task is not configured for PDF conversion")
             task_id = self.background_task.add_task(
                 convert_pdf_to_image,
                 image_id,
@@ -212,7 +213,7 @@ class UploadService:
             # 画像情報を取得
             image_data = get_image(image_id)
             if not image_data:
-                raise ValueError("Image not found")
+                raise NotFoundError("画像が見つかりません")
 
             # S3キーを抽出（リスト・文字列両対応）
             def extract_s3_keys_from_dynamo_data(dynamo_data):
@@ -237,7 +238,7 @@ class UploadService:
                 bucket_name = self.bucket_name
                 logger.info(f"元画像のダウンロードURLを生成します: {bucket_name}")
             else:
-                raise ValueError("Image file not found")
+                raise NotFoundError("画像ファイルが見つかりません")
 
             # 複数ページの署名付きURLを生成
             presigned_urls = []
@@ -284,7 +285,7 @@ class UploadService:
                     main_content_type = content_type
 
             if not presigned_urls:
-                raise ValueError("No valid S3 keys found")
+                raise NotFoundError("有効な S3 キーが見つかりません")
 
             logger.info(f"Generated download URL for image {image_id}")
 

--- a/lambda/api/app/tests/repositories/test_job_status.py
+++ b/lambda/api/app/tests/repositories/test_job_status.py
@@ -5,6 +5,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
 
 import pytest
 
+from exceptions import BadRequestError
 from repositories.job_repository import (
     SuggestionStatus, validate_suggestion_status,
     JobStatus, validate_job_status,
@@ -17,7 +18,8 @@ class TestSuggestionStatus:
             validate_suggestion_status(s)
 
     def test_invalid_rejected(self):
-        with pytest.raises(ValueError):
+        # 無効値は BadRequestError（400）になる
+        with pytest.raises(BadRequestError):
             validate_suggestion_status("bogus")
 
 
@@ -27,5 +29,5 @@ class TestJobStatus:
             validate_job_status(s)
 
     def test_invalid_rejected(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(BadRequestError):
             validate_job_status("bogus")

--- a/lambda/api/app/tests/routers/test_error_handlers.py
+++ b/lambda/api/app/tests/routers/test_error_handlers.py
@@ -1,0 +1,190 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+from errors import register_error_handlers
+from exceptions import (
+    NotFoundError, BadRequestError, ForbiddenError, ConflictError,
+    LastOwnerError, EndpointNotReadyError,
+)
+
+# main.py は import 時に全 service（AWS クライアント）を構築するため import せず、
+# ハンドラだけを適用した最小アプリで検証する。
+app = FastAPI()
+app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+register_error_handlers(app)
+
+
+class _Body(BaseModel):
+    name: str
+
+
+@app.get("/http-string")
+def _http_string():
+    raise HTTPException(status_code=404, detail="Image not found")
+
+
+@app.get("/http-dict")
+def _http_dict():
+    raise HTTPException(status_code=503, detail={"error": "endpoint_not_ready", "message": "起動中です"})
+
+
+@app.get("/http-500")
+def _http_500():
+    raise HTTPException(status_code=500, detail="Error: secret internal detail")
+
+
+@app.get("/http-500-dict")
+def _http_500_dict():
+    # error コードを持たない 5xx dict はマスクされるべき（内部情報を漏らさない）
+    raise HTTPException(status_code=500, detail={"message": "secret dict detail"})
+
+
+@app.get("/boom")
+def _boom():
+    raise RuntimeError("secret crash detail")
+
+
+@app.post("/validate")
+def _validate(body: _Body):
+    return {"ok": body.name}
+
+
+# --- domain 例外の各種 ---
+@app.get("/err/not-found")
+def _err_not_found():
+    raise NotFoundError("見つかりません")
+
+
+@app.get("/err/bad-request")
+def _err_bad_request():
+    raise BadRequestError("不正な入力です")
+
+
+@app.get("/err/forbidden")
+def _err_forbidden():
+    raise ForbiddenError("権限がありません")
+
+
+@app.get("/err/conflict")
+def _err_conflict():
+    raise ConflictError("競合しています")
+
+
+@app.get("/err/last-owner")
+def _err_last_owner():
+    raise LastOwnerError("最後のオーナーは削除できません")
+
+
+@app.get("/err/endpoint-not-ready")
+def _err_endpoint_not_ready():
+    raise EndpointNotReadyError("Endpoint warming up")
+
+
+@app.get("/err/value-error")
+def _err_value_error():
+    # domain 例外でない素の ValueError は 500 になる（ValueError 専用ハンドラは無い）
+    raise ValueError("some library value error")
+
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def test_http_string_detail():
+    r = client.get("/http-string")
+    assert r.status_code == 404
+    assert r.json() == {"detail": "Image not found", "code": None}
+
+
+def test_endpoint_not_ready_dict_preserves_code():
+    r = client.get("/http-dict")
+    assert r.status_code == 503
+    body = r.json()
+    assert body["code"] == "endpoint_not_ready"
+    assert body["detail"] == "起動中です"
+
+
+def test_500_hides_internal_detail():
+    r = client.get("/http-500")
+    assert r.status_code == 500
+    body = r.json()
+    assert body["code"] == "internal_error"
+    assert "secret" not in body["detail"]  # 内部情報がクライアントに漏れない
+
+
+def test_500_dict_without_error_code_is_masked():
+    r = client.get("/http-500-dict")
+    assert r.status_code == 500
+    body = r.json()
+    assert body["code"] == "internal_error"
+    assert "secret" not in body["detail"]  # error コード無しの 5xx dict も漏らさない
+
+
+def test_unhandled_exception_is_masked():
+    r = client.get("/boom")
+    assert r.status_code == 500
+    body = r.json()
+    assert body["code"] == "internal_error"
+    assert "secret" not in body["detail"]
+
+
+def test_validation_error_becomes_string():
+    r = client.post("/validate", json={})  # name 欠落
+    assert r.status_code == 422
+    body = r.json()
+    assert body["code"] == "validation_error"
+    assert isinstance(body["detail"], str)  # 配列でなく文字列
+    assert body["detail"]  # 非空
+
+
+def test_framework_404_has_code_key():
+    # 未マッチルート（純 starlette の 404）も統一形になる
+    r = client.get("/no-such-route")
+    assert r.status_code == 404
+    assert "code" in r.json()
+
+
+def test_cors_header_present_on_error():
+    r = client.get("/http-string", headers={"Origin": "https://example.com"})
+    assert r.headers.get("access-control-allow-origin") == "*"
+
+
+# --- domain 例外 → (status, code) マッピング ---
+@pytest.mark.parametrize("path,status,code", [
+    ("/err/not-found", 404, "not_found"),
+    ("/err/bad-request", 400, "bad_request"),
+    ("/err/forbidden", 403, "forbidden"),
+    ("/err/conflict", 409, "conflict"),
+    ("/err/last-owner", 400, "last_owner"),
+])
+def test_domain_exception_mapping(path, status, code):
+    r = client.get(path)
+    assert r.status_code == status
+    body = r.json()
+    assert body["code"] == code
+    assert isinstance(body["detail"], str) and body["detail"]
+
+
+def test_endpoint_not_ready_via_app_error_preserves_code():
+    # 503 でも code を持つ AppError は message/code を保持（FE 契約）
+    r = client.get("/err/endpoint-not-ready")
+    assert r.status_code == 503
+    body = r.json()
+    assert body["code"] == "endpoint_not_ready"
+    assert body["detail"] == "Endpoint warming up"
+
+
+def test_bare_value_error_becomes_500():
+    # ValueError 専用ハンドラは無いので想定外の 500 になる（中身は隠す）
+    r = client.get("/err/value-error")
+    assert r.status_code == 500
+    body = r.json()
+    assert body["code"] == "internal_error"
+    assert "library value error" not in body["detail"]

--- a/web/src/components/shared/CustomPromptModal.tsx
+++ b/web/src/components/shared/CustomPromptModal.tsx
@@ -34,7 +34,7 @@ const CustomPromptModal: React.FC<CustomPromptModalProps> = ({
       const response = await api.get(`/apps/${appName}/custom-prompt`);
       setCustomPrompt(response.data.custom_prompt || "");
     } catch (err: any) {
-      setError(`カスタムプロンプトの読み込みに失敗しました: ${err.message}`);
+      setError(`カスタムプロンプトの読み込みに失敗しました: ${err?.userMessage ?? err?.message ?? "不明なエラー"}`);
     } finally {
       setIsLoading(false);
     }
@@ -51,7 +51,7 @@ const CustomPromptModal: React.FC<CustomPromptModalProps> = ({
       setSuccessMessage("カスタムプロンプトを保存しました");
       setTimeout(() => setSuccessMessage(null), 3000);
     } catch (err: any) {
-      setError(`カスタムプロンプトの保存に失敗しました: ${err.message}`);
+      setError(`カスタムプロンプトの保存に失敗しました: ${err?.userMessage ?? err?.message ?? "不明なエラー"}`);
     } finally {
       setIsSaving(false);
     }
@@ -120,7 +120,7 @@ const CustomPromptModal: React.FC<CustomPromptModalProps> = ({
 
               {error && (
                 <Alert type="error" className="mb-4">
-                  <span className="block sm:inline">{error}</span>
+                  <span className="block sm:inline whitespace-pre-line">{error}</span>
                 </Alert>
               )}
 

--- a/web/src/pages/ocr-result/OCRResult.tsx
+++ b/web/src/pages/ocr-result/OCRResult.tsx
@@ -938,7 +938,7 @@ function OcrResult() {
       startPolling();
     } catch (error: any) {
       console.error("再抽出エラー:", error);
-      showToast(error.response?.data?.detail?.message || error.response?.data?.detail || "再抽出に失敗しました", "error");
+      showToast(error?.userMessage ?? error?.message ?? "再抽出に失敗しました", "error");
       setExtractionStatus("failed");
     }
   };

--- a/web/src/pages/schema/SchemaGenerator.tsx
+++ b/web/src/pages/schema/SchemaGenerator.tsx
@@ -4,7 +4,7 @@ import { Info } from "lucide-react";
 import SchemaPreview from "./SchemaPreview";
 import SchemaFieldsEditor from "./SchemaFieldsEditor";
 import { Field } from "../../types/app-schema";
-import api, { extractApiErrorMessage } from "../../services/api";
+import api from "../../services/api";
 import { validateSchemaFields, isValidAppName } from "../../utils/schemaValidation";
 import { useAppContext } from "../../contexts/AppContext";
 import { Alert, Button, Skeleton } from "../../components/ui";
@@ -102,7 +102,7 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
           setAgentEnabled(appData.agent_enabled || false);
         })
         .catch((err) => {
-          setError(`スキーマの読み込みに失敗しました: ${err.message}`);
+          setError(`スキーマの読み込みに失敗しました: ${err?.userMessage ?? err?.message ?? "不明なエラー"}`);
         })
         .finally(() => {
           setIsLoading(false);
@@ -330,7 +330,7 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
       }
     } catch (err: any) {
       console.error("スキーマ生成エラー:", err);
-      setError(`スキーマ生成に失敗しました:\n${extractApiErrorMessage(err)}`);
+      setError(`スキーマ生成に失敗しました:\n${err?.userMessage ?? err?.message ?? "不明なエラー"}`);
     } finally {
       setIsGenerating(false);
     }
@@ -432,8 +432,7 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
       }, 3000);
     } catch (err: any) {
       console.error("スキーマ保存エラー:", err);
-      const errorMessage = extractApiErrorMessage(err);
-      setError(`スキーマの保存に失敗しました:\n${errorMessage}`);
+      setError(`スキーマの保存に失敗しました:\n${err?.userMessage ?? err?.message ?? "不明なエラー"}`);
       setSuccessMessage(null); // 成功メッセージをクリア
     } finally {
       setIsSaving(false);
@@ -673,7 +672,7 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
                                           tool_ids: updated.map((t: any) => t.id),
                                         }).catch((err: any) => {
                                           setUsecaseTools(prev);
-                                          setError(`ツール解除に失敗しました: ${err.response?.data?.detail || err.message}`);
+                                          setError(`ツール解除に失敗しました: ${err?.userMessage ?? err?.message ?? "不明なエラー"}`);
                                         });
                                       }}
                                       className="w-5 h-5 flex items-center justify-center rounded text-danger hover:bg-danger-light text-sm font-bold"
@@ -710,7 +709,7 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
                                             tool_ids: updated.map((t: any) => t.id),
                                           }).catch((err: any) => {
                                             setUsecaseTools(prev);
-                                            setError(`ツール追加に失敗しました: ${err.response?.data?.detail || err.message}`);
+                                            setError(`ツール追加に失敗しました: ${err?.userMessage ?? err?.message ?? "不明なエラー"}`);
                                           });
                                         }}
                                         className="w-5 h-5 flex items-center justify-center rounded text-primary hover:bg-primary/10 text-sm font-bold"

--- a/web/src/pages/schema/UsecaseSettings.tsx
+++ b/web/src/pages/schema/UsecaseSettings.tsx
@@ -58,7 +58,7 @@ const UsecaseSettings: React.FC<UsecaseSettingsProps> = ({ mode = 'create' }) =>
           setAgentEnabled(appData.agent_enabled || false);
         })
         .catch((err) => {
-          setError(`設定の読み込みに失敗しました: ${err.message}`);
+          setError(`設定の読み込みに失敗しました: ${err?.userMessage ?? err?.message ?? "不明なエラー"}`);
         })
         .finally(() => {
           setIsLoading(false);
@@ -133,8 +133,7 @@ const UsecaseSettings: React.FC<UsecaseSettingsProps> = ({ mode = 'create' }) =>
         return;
       }
     } catch (err: any) {
-      const msg = err.response?.data?.detail || err.message || "不明なエラー";
-      setError(`保存に失敗しました: ${msg}`);
+      setError(`保存に失敗しました: ${err?.userMessage ?? err?.message ?? "不明なエラー"}`);
     } finally {
       setIsSaving(false);
     }
@@ -196,7 +195,7 @@ const UsecaseSettings: React.FC<UsecaseSettingsProps> = ({ mode = 'create' }) =>
 
           {error && (
             <Alert type="error" className="mb-6">
-              <span className="block sm:inline">{error}</span>
+              <span className="block sm:inline whitespace-pre-line">{error}</span>
             </Alert>
           )}
 
@@ -359,7 +358,7 @@ const UsecaseSettings: React.FC<UsecaseSettingsProps> = ({ mode = 'create' }) =>
                                         tool_ids: updated.map((t: any) => t.id),
                                       }).catch((err: any) => {
                                         setUsecaseTools(prev);
-                                        setError(`ツール解除に失敗しました: ${err.response?.data?.detail || err.message}`);
+                                        setError(`ツール解除に失敗しました: ${err?.userMessage ?? err?.message ?? "不明なエラー"}`);
                                       });
                                     }}
                                     className="w-5 h-5 flex items-center justify-center rounded text-danger hover:bg-danger-light text-sm font-bold"
@@ -396,7 +395,7 @@ const UsecaseSettings: React.FC<UsecaseSettingsProps> = ({ mode = 'create' }) =>
                                           tool_ids: updated.map((t: any) => t.id),
                                         }).catch((err: any) => {
                                           setUsecaseTools(prev);
-                                          setError(`ツール追加に失敗しました: ${err.response?.data?.detail || err.message}`);
+                                          setError(`ツール追加に失敗しました: ${err?.userMessage ?? err?.message ?? "不明なエラー"}`);
                                         });
                                       }}
                                       className="w-5 h-5 flex items-center justify-center rounded text-primary hover:bg-primary/10 text-sm font-bold"

--- a/web/src/pages/upload/S3SyncModal.tsx
+++ b/web/src/pages/upload/S3SyncModal.tsx
@@ -31,7 +31,7 @@ const S3SyncModal: React.FC<S3SyncModalProps> = ({ isOpen, onClose, appName, onI
       setFiles(response.data.files || []);
     } catch (err: any) {
       console.error('S3ファイル一覧の取得に失敗しました:', err);
-      setError(err.response?.data?.detail || 'S3ファイル一覧の取得に失敗しました');
+      setError(err?.userMessage ?? err?.message ?? 'S3ファイル一覧の取得に失敗しました');
     } finally {
       setLoading(false);
     }
@@ -103,7 +103,7 @@ const S3SyncModal: React.FC<S3SyncModalProps> = ({ isOpen, onClose, appName, onI
       
     } catch (err: any) {
       console.error('ファイルのインポートに失敗しました:', err);
-      setError(err.response?.data?.detail || 'ファイルのインポートに失敗しました');
+      setError(err?.userMessage ?? err?.message ?? 'ファイルのインポートに失敗しました');
     } finally {
       setImporting(false);
     }
@@ -159,7 +159,7 @@ const S3SyncModal: React.FC<S3SyncModalProps> = ({ isOpen, onClose, appName, onI
         <div className="p-4">
           {error && (
             <Alert type="error" className="mb-4">
-              <p>{error}</p>
+              <p className="whitespace-pre-line">{error}</p>
             </Alert>
           )}
 

--- a/web/src/pages/upload/Upload.tsx
+++ b/web/src/pages/upload/Upload.tsx
@@ -96,7 +96,7 @@ function Upload() {
       console.error("OCR処理の開始に失敗しました:", error);
       
       // エンドポイント起動中エラーの場合
-      if (error.response?.status === 503 && error.response?.data?.detail?.error === 'endpoint_not_ready') {
+      if (error.response?.status === 503 && error.apiErrorCode === 'endpoint_not_ready') {
         setIsEndpointWarming(true);
         setIsProcessing(false);
 
@@ -163,7 +163,7 @@ function Upload() {
       await refreshApps();
       navigate('/');
     } catch (err: any) {
-      setError(`削除に失敗しました: ${err.message}`);
+      setError(`削除に失敗しました: ${err?.userMessage ?? err?.message ?? "不明なエラー"}`);
     }
   };
 
@@ -386,7 +386,7 @@ function Upload() {
 
           {error && (
             <Alert type="error" className="mb-4">
-              <span className="block sm:inline">{error}</span>
+              <span className="block sm:inline whitespace-pre-line">{error}</span>
             </Alert>
           )}
 

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -103,14 +103,12 @@ function formatDetailEntry(d: any): string {
 
 /**
  * API エラーから表示用の日本語メッセージを整形する（interceptor 専用の非公開 helper）。
- * バックエンドは errors.py で detail を string に統一済みなので通常はその主経路を通る。
- * 配列（422）/ 構造化オブジェクト分岐は、ハンドラを通らない API Gateway/ALB 由来の
- * エラー（502/504 等）への防御として残す。常に非空文字列を返す。
+ * detail は通常 string だが、配列 / オブジェクト形も読めるようにして常に非空文字列を返す。
  */
 function formatApiError(err: any, fallback = '不明なエラーが発生しました'): string {
   const detail = err?.response?.data?.detail;
   if (typeof detail === 'string') return detail;
-  // 以下は防御（バックエンドが正規化済みなら通常到達しない）
+  // API Gateway/ALB など、通常の detail:string に沿わない形式への防御
   if (Array.isArray(detail)) {
     const lines = detail.map(formatDetailEntry).filter(Boolean);
     if (lines.length > 0) return lines.join('\n');

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,6 +1,16 @@
 import axios from 'axios';
 import { fetchAuthSession } from 'aws-amplify/auth';
 
+// axios のエラーに、表示用メッセージと機械判定コードを添付する。
+// interceptor が必ず生やすので、各ページは err.userMessage / err.apiErrorCode を読むだけでよい。
+// apiErrorCode は axios ネイティブの AxiosError.code（ECONNABORTED 等）との衝突を避けた命名。
+declare module 'axios' {
+  interface AxiosError {
+    userMessage?: string;
+    apiErrorCode?: string | null;
+  }
+}
+
 // 環境変数からAPIのベースURLを取得
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
 
@@ -74,6 +84,9 @@ api.interceptors.response.use(
         console.error('API Config Error:', error.message);
       }
     }
+    // 表示用メッセージと機械判定コードを1回だけ生成して添付する
+    error.userMessage = formatApiError(error);
+    error.apiErrorCode = error.response?.data?.code ?? null;
     return Promise.reject(error);
   }
 );
@@ -89,16 +102,22 @@ function formatDetailEntry(d: any): string {
 }
 
 /**
- * API エラーから表示用メッセージを取り出す。
- * FastAPI の 422 は detail が配列（[{loc, msg, type}, ...]）で返るため、
- * そのままだと "[object Object]" になる。string / 配列 の両方を読める形に整形する。
+ * API エラーから表示用の日本語メッセージを整形する（interceptor 専用の非公開 helper）。
+ * バックエンドは errors.py で detail を string に統一済みなので通常はその主経路を通る。
+ * 配列（422）/ 構造化オブジェクト分岐は、ハンドラを通らない API Gateway/ALB 由来の
+ * エラー（502/504 等）への防御として残す。常に非空文字列を返す。
  */
-export function extractApiErrorMessage(err: any, fallback = '不明なエラーが発生しました'): string {
+function formatApiError(err: any, fallback = '不明なエラーが発生しました'): string {
   const detail = err?.response?.data?.detail;
   if (typeof detail === 'string') return detail;
+  // 以下は防御（バックエンドが正規化済みなら通常到達しない）
   if (Array.isArray(detail)) {
     const lines = detail.map(formatDetailEntry).filter(Boolean);
     if (lines.length > 0) return lines.join('\n');
+  }
+  if (detail && typeof detail === 'object') {
+    if (typeof detail.message === 'string') return detail.message;
+    if (typeof detail.error === 'string') return detail.error;
   }
   return err?.message || fallback;
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Unifies API error handling end to end. Previously error responses were inconsistent — `HTTPException` details were sometimes a string, sometimes a dict, and 422 validation errors leaked FastAPI's default array shape; services raised bare `ValueError` that routers converted to HTTP status codes inconsistently (the same "not found" could become 400 in one route and 404 in another); and the frontend hand-parsed `err.response.data.detail` in many places, breaking (`[object Object]`) on the array shape.

### Backend

- **Single response contract**: all error responses are now `{"detail": "<message>", "code": "<machine-code|null>"}`. A new `errors.py` registers FastAPI exception handlers (via `@app.exception_handler`, so they run inside CORSMiddleware and error responses keep CORS headers):
  - domain exceptions → their status + code
  - `RequestValidationError` (422) → a single joined message, `code: "validation_error"` (no more array leak)
  - unhandled `Exception` and any 5xx → generic message, `code: "internal_error"` (internal details are logged server-side, never returned to the client)
- **Domain exceptions**: new `exceptions.py` defines an `AppError` hierarchy (`NotFoundError` 404, `BadRequestError` 400, `ForbiddenError` 403, `ConflictError` 409, `LastOwnerError` 400, `EndpointNotReadyError` 503). Services/repositories now raise these instead of `ValueError`, so status codes are deterministic and defined at the source. Config/env failures raise `RuntimeError` (→ masked 500). Three previously scattered custom exceptions are consolidated here.
- **Routers slimmed**: ~33 catch-all `except Exception → HTTPException(500)` wrappers and the redundant `except`/re-convert blocks were removed; exceptions now propagate to the global handlers. Inline permission/existence `raise HTTPException(...)` in router bodies are kept as-is.
- User-facing messages are unified to Japanese; background-worker-only messages are left untouched.

### Frontend

- The axios response interceptor attaches `err.userMessage` (display string) and `err.apiErrorCode` (machine code) once, centrally. Call sites simply read `err.userMessage` instead of re-parsing `detail`. The endpoint-warmup control flow now reads `err.apiErrorCode === 'endpoint_not_ready'`.

### Verification

- Backend pytest 70 passed (new handler-mapping tests: each domain exception → status/code, 422→string, 5xx masking, unhandled→500, CORS present on error). pyflakes clean. Completeness gate: zero `raise ValueError` remain in services/repositories, zero `except ValueError` in routers.
- Frontend build passes.
- Verified end to end on a test environment: not-found → `404 {detail: <Japanese>, code: "not_found"}`, invalid save → `422 {detail: <Japanese>, code: "validation_error"}`, normal reads unaffected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.