### PR TITLE
refactor: rework agent configuration into per-usecase flags

### DIFF
--- a/agentcore/runtime/src/tools.py
+++ b/agentcore/runtime/src/tools.py
@@ -83,25 +83,25 @@ def create_gateway_mcp_client(
     """SigV4 署名付き MCPClient を生成。
 
     Args:
-        allowed_tool_names: 許可するツール名のリスト。None の場合は全ツールを公開。
+        allowed_tool_names: 許可するツール名のリスト。空/None の場合はツールを公開しない
+            （LLM 単体で処理させる）。全ツールを無条件公開するモードは設けない。
 
     Returns:
-        MCPClient instance or None if Gateway URL is not configured.
+        MCPClient instance、または Gateway URL 未設定・許可ツールなしの場合は None。
     """
+    if not allowed_tool_names:
+        return None
+
     gateway_url = os.environ.get("AGENTCORE_GATEWAY_ENDPOINT")
     if not gateway_url:
         logger.warning("AGENTCORE_GATEWAY_ENDPOINT not set. Gateway tools disabled.")
         return None
 
     auth = SigV4HttpxAuth()
-
-    if allowed_tool_names:
-        client = FilteredMCPClient(
-            lambda: streamablehttp_client(gateway_url, auth=auth),
-            allowed_tool_names=allowed_tool_names,
-        )
-    else:
-        client = MCPClient(lambda: streamablehttp_client(gateway_url, auth=auth))
+    client = FilteredMCPClient(
+        lambda: streamablehttp_client(gateway_url, auth=auth),
+        allowed_tool_names=allowed_tool_names,
+    )
 
     logger.info(f"Gateway MCP client created: {gateway_url}")
     return client

--- a/lambda/api/app/repositories/schema_repository.py
+++ b/lambda/api/app/repositories/schema_repository.py
@@ -46,6 +46,7 @@ def load_app_schemas():
                     'input_methods': item.get('input_methods', {'file_upload': True, 's3_sync': False}),
                     'custom_prompt': item.get('custom_prompt', ''),
                     'agent_enabled': item.get('agent_enabled', False),
+                    'agent_auto_run': item.get('agent_auto_run', False),
                     'sample_image_s3_key': item.get('sample_image_s3_key'),
                     'sample_image_filename': item.get('sample_image_filename'),
                     'schema_instructions': item.get('schema_instructions', ''),
@@ -146,6 +147,7 @@ def create_app_schema(app_name, app_data):
             'fields': app_data.get('fields', []),
             'input_methods': app_data.get('input_methods', {'file_upload': True, 's3_sync': False}),
             'agent_enabled': app_data.get('agent_enabled', False),
+            'agent_auto_run': app_data.get('agent_auto_run', False),
             'created_at': current_time,
             'updated_at': current_time
         }
@@ -213,6 +215,7 @@ def update_app_schema(app_name, app_data):
             'fields': app_data.get('fields', []),
             'input_methods': app_data.get('input_methods', {'file_upload': True, 's3_sync': False}),
             'agent_enabled': app_data.get('agent_enabled', False),
+            'agent_auto_run': app_data.get('agent_auto_run', False),
             'created_at': created_at,
             'updated_at': current_time
         }

--- a/lambda/api/app/routers/images.py
+++ b/lambda/api/app/routers/images.py
@@ -26,6 +26,7 @@ from dependencies.auth import (
 )
 from repositories import get_image
 from repositories.job_repository import get_latest_agent_job_by_image_id, update_suggestion_status, SuggestionStatus
+from domains.image_status import AgentStatus
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/images", tags=["Images"])
@@ -210,6 +211,11 @@ async def get_agent_job_by_image(
     """画像の最新エージェントジョブを取得"""
     image = get_image(image_id)
     image_agent_status = image.get("agent_status") if image else None
+
+    # 抽出開始時に agent_status は idle にリセットされる。idle/未設定なら過去ジョブは
+    # 現在の抽出と無関係なので返さない（再抽出後に古い検証結果が復活するのを防ぐ）。
+    if image_agent_status in (None, AgentStatus.IDLE):
+        return {"status": "none", "suggestions": []}
 
     job = get_latest_agent_job_by_image_id(image_id)
     if not job:

--- a/lambda/api/app/schemas/schema.py
+++ b/lambda/api/app/schemas/schema.py
@@ -87,7 +87,10 @@ class SchemaSaveRequest(BaseModel):
     description: Optional[str] = None
     fields: List[SchemaField]
     input_methods: Dict[str, Any]
+    # agent_enabled: このユースケースでエージェント検証を使うか（手動実行の可否）。
+    # agent_auto_run: 抽出後に自動実行するか。agent_enabled が前提。
     agent_enabled: bool = False
+    agent_auto_run: bool = False
     # スキーマ生成に使ったサンプル画像の S3 キー (schema-uploads/ 配下)。
     # None の場合、update 時は既存値を保持する (画像未変更の編集で消えないように)。
     sample_image_s3_key: Optional[str] = None

--- a/lambda/api/app/services/agent_service.py
+++ b/lambda/api/app/services/agent_service.py
@@ -46,7 +46,7 @@ class AgentService:
             lambda_client.invoke(
                 FunctionName=settings.AGENT_KICK_FUNCTION_NAME,
                 InvocationType="Event",  # async
-                Payload=json.dumps({"image_id": image_id, "job_id": job_id}),
+                Payload=json.dumps({"image_id": image_id, "job_id": job_id, "manual": True}),
             )
             logger.info(f"Invoked AgentKick Lambda for job {job_id}")
 

--- a/lambda/api/app/services/agent_service.py
+++ b/lambda/api/app/services/agent_service.py
@@ -81,13 +81,8 @@ class AgentService:
             app_name = image_data.get("app_name", "")
             usecase = get_usecase_by_app_name(app_name) if app_name else None
             usecase_id = str(usecase["id"]) if usecase else ""
+            # ツール未割当でも LLM 単体で検証を実行する（allowed_tool_names 空 → invoke_agent には None を渡す）
             allowed_tool_names = get_usecase_allowed_tool_names(usecase_id) if usecase_id else []
-
-            # Skip agent execution if no tools are configured
-            if not allowed_tool_names:
-                logger.info(f"No tools configured for usecase '{app_name}'. Skipping agent.")
-                update_agent_job(job_id, JobStatus.SKIPPED)
-                return
 
             # Fetch images from S3
             image_content = self._fetch_images(image_data)
@@ -104,7 +99,7 @@ class AgentService:
                     "modelId": settings.MODEL_ID,
                     "region": settings.MODEL_REGION
                 },
-                allowed_tool_names=allowed_tool_names or None,
+                allowed_tool_names=allowed_tool_names,
                 image_content=image_content or None,
             )
 

--- a/lambda/api/app/services/ocr_service.py
+++ b/lambda/api/app/services/ocr_service.py
@@ -356,7 +356,9 @@ class OcrService:
             # 再処理の起点。抽出フェーズへの遷移は extract() 冒頭が担う。
             update_image_status(image_id, ImageStatus.OCR, job_id)
 
-            update_agent_status(image_id, AgentStatus.PROCESSING, suggestions_count=0)
+            # agent 検証は AgentKick が実行時に PROCESSING へ更新する。ここでは過去結果を
+            # 破棄する意味で idle に戻す（auto_run 無効なら idle のまま＝抽出で完結）。
+            update_agent_status(image_id, AgentStatus.IDLE, suggestions_count=0)
 
             # Step Functions起動（単一画像）
             execution_response = sfn_client.start_execution(

--- a/lambda/api/app/services/schema_service.py
+++ b/lambda/api/app/services/schema_service.py
@@ -55,6 +55,7 @@ class SchemaService:
             "fields": [f.model_dump(exclude_none=True) for f in request.fields],
             "input_methods": request.input_methods,
             "agent_enabled": request.agent_enabled,
+            "agent_auto_run": request.agent_auto_run,
             "sample_image_s3_key": request.sample_image_s3_key,
             "sample_image_filename": request.sample_image_filename,
             "schema_instructions": request.schema_instructions,

--- a/lambda/api/app/workers/agent_kick.py
+++ b/lambda/api/app/workers/agent_kick.py
@@ -65,15 +65,21 @@ def agent_kick_handler(event, context):
         sync_parent_agent_status(image_id)
         return {"status": "skipped", "reason": "no app_name"}
 
-    # 自動実行は agent_enabled かつ agent_auto_run のときのみ。
-    # 手動実行は別経路で、このゲートを通らない。
+    # 手動実行（manual=True）は agent_enabled のみ要求し、自動実行判定を通さない。
+    # 自動実行（Step Functions 経由）は agent_enabled かつ agent_auto_run のときのみ。
+    is_manual = event.get("manual", False)
     schema = get_app_schema(app_name)
-    if not schema or not schema.get("agent_enabled", False) or not schema.get("agent_auto_run", False):
-        logger.info(f"Agent auto-run not enabled for app: {app_name}")
-        _update_agent_status(image_id, AgentStatus.SKIPPED)
+    enabled = bool(schema and schema.get("agent_enabled", False))
+    allowed = enabled if is_manual else (enabled and bool(schema.get("agent_auto_run", False)))
+    if not allowed:
+        reason = "agent_enabled=false" if is_manual else "agent_auto_run=false"
+        logger.info(f"Agent skipped for app {app_name} (manual={is_manual}): {reason}")
+        # 検証対象外のユースケースは「検証していない」状態＝idle にする。
+        # SKIPPED にすると GET /agent が過去ジョブを返し古い結果が復活するため。
+        _update_agent_status(image_id, AgentStatus.IDLE)
         _finalize_skipped_job(event)
         sync_parent_agent_status(image_id)
-        return {"status": "skipped", "reason": "agent_auto_run=false"}
+        return {"status": "skipped", "reason": reason}
 
     job_id = event.get("job_id")
     try:

--- a/lambda/api/app/workers/agent_kick.py
+++ b/lambda/api/app/workers/agent_kick.py
@@ -65,14 +65,15 @@ def agent_kick_handler(event, context):
         sync_parent_agent_status(image_id)
         return {"status": "skipped", "reason": "no app_name"}
 
-    # Check agent_enabled (avoid unnecessary job creation)
+    # 自動実行は agent_enabled かつ agent_auto_run のときのみ。
+    # 手動実行は別経路で、このゲートを通らない。
     schema = get_app_schema(app_name)
-    if not schema or not schema.get("agent_enabled", False):
-        logger.info(f"Agent not enabled for app: {app_name}")
+    if not schema or not schema.get("agent_enabled", False) or not schema.get("agent_auto_run", False):
+        logger.info(f"Agent auto-run not enabled for app: {app_name}")
         _update_agent_status(image_id, AgentStatus.SKIPPED)
         _finalize_skipped_job(event)
         sync_parent_agent_status(image_id)
-        return {"status": "skipped", "reason": "agent_enabled=false"}
+        return {"status": "skipped", "reason": "agent_auto_run=false"}
 
     job_id = event.get("job_id")
     try:

--- a/lambda/demo-custom-resource/index.py
+++ b/lambda/demo-custom-resource/index.py
@@ -104,6 +104,7 @@ def insert_demo_usecase(dynamodb, table_name):
             's3_sync': False
         },
         'agent_enabled': True,
+        'agent_auto_run': True,
         'created_at': datetime.now(timezone.utc).isoformat(),
         'updated_at': datetime.now(timezone.utc).isoformat()
     }

--- a/lib/constructs/step-functions.ts
+++ b/lib/constructs/step-functions.ts
@@ -23,7 +23,6 @@ export interface StepFunctionsProps {
   sagemakerInferenceComponentName?: string;
   modelId: string;
   modelRegion: string;
-  enableAgent?: boolean;
   agentRuntimeArn?: string;
   dsqlEndpoint?: string;
   dsqlRegion?: string;
@@ -85,7 +84,7 @@ export class StepFunctions extends Construct {
     // AgentKick Lambda (runs after ProcessImage, checks agent_enabled internally)
     let chainedDefinition: cdk.aws_stepfunctions.IChainable = processImageTask;
 
-    if (props.enableAgent && props.agentRuntimeArn) {
+    if (props.agentRuntimeArn) {
       const agentKick = new DockerImageFunction(this, 'AgentKick', {
         code: DockerImageCode.fromImageAsset('lambda/api', {
           file: 'Dockerfile.agentkick',

--- a/lib/constructs/web.ts
+++ b/lib/constructs/web.ts
@@ -13,7 +13,6 @@ export interface WebProps {
   userPoolClientId: string;
   apiUrl: string;
   enableOcr: boolean;
-  enableAgent: boolean;
   syncBucketName: string;
   webAclArn?: string;
   /** WebSocket プレゼンス機能のエンドポイント URL */
@@ -23,7 +22,7 @@ export class Web extends Construct {
   constructor(scope: Construct, id: string, props: WebProps) {
     super(scope, id);
 
-    const { buildFolder, userPoolId, userPoolClientId, apiUrl, enableOcr, enableAgent, syncBucketName, webAclArn, websocketUrl } = props;
+    const { buildFolder, userPoolId, userPoolClientId, apiUrl, enableOcr, syncBucketName, webAclArn, websocketUrl } = props;
 
     const bucketProps: s3.BucketProps = {
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
@@ -111,7 +110,6 @@ export class Web extends Construct {
         VITE_APP_REGION: Stack.of(this).region,
         VITE_API_BASE_URL: apiUrl,
         VITE_ENABLE_OCR: enableOcr.toString(),
-        VITE_ENABLE_AGENT: enableAgent.toString(),
         VITE_SYNC_BUCKET_NAME: syncBucketName,
         VITE_WEBSOCKET_URL: websocketUrl,
       },

--- a/lib/ocr-app-stack.ts
+++ b/lib/ocr-app-stack.ts
@@ -57,19 +57,16 @@ export class OcrAppStack extends cdk.Stack {
       ocrEndpoint = ocr;
     }
 
-    let agent = undefined;
-    if (p.enableAgent) {
-      agent = new Agent(this, "Agent", {
-        region: this.region,
-        enableDemo: p.enableAgentDemo,
-        schemasTable: database.schemasTable,
-        dsqlEndpoint: dsql.clusterEndpoint,
-        dsqlRegion: this.region,
-        dsqlClusterArn: dsql.clusterArn,
-        dsqlDdlResource: dsql.ddlResource,
-        dsqlSeedResource: dsql.seedResource,
-      });
-    }
+    const agent = new Agent(this, "Agent", {
+      region: this.region,
+      enableDemo: p.enableAgentDemo,
+      schemasTable: database.schemasTable,
+      dsqlEndpoint: dsql.clusterEndpoint,
+      dsqlRegion: this.region,
+      dsqlClusterArn: dsql.clusterArn,
+      dsqlDdlResource: dsql.ddlResource,
+      dsqlSeedResource: dsql.seedResource,
+    });
 
     const api = new Api(this, "Api", {
       imagesTable: database.imagesTable,
@@ -83,7 +80,7 @@ export class OcrAppStack extends cdk.Stack {
       ocrEngine: p.ocrEngine,
       sagemakerEndpointName: ocrEndpoint?.endpointName,
       sagemakerInferenceComponentName: ocrEndpoint?.inferenceComponentName,
-      agentRuntimeArn: agent?.runtimeArn,
+      agentRuntimeArn: agent.runtimeArn,
       modelId: p.modelId,
       modelRegion: p.modelRegion,
       dsqlEndpoint: dsql.clusterEndpoint,
@@ -102,8 +99,7 @@ export class OcrAppStack extends cdk.Stack {
       sagemakerInferenceComponentName: ocrEndpoint?.inferenceComponentName,
       modelId: p.modelId,
       modelRegion: p.modelRegion,
-      enableAgent: p.enableAgent,
-      agentRuntimeArn: agent?.runtimeArn,
+      agentRuntimeArn: agent.runtimeArn,
       dsqlEndpoint: dsql.clusterEndpoint,
       dsqlRegion: this.region,
       dsqlClusterArn: dsql.clusterArn,
@@ -141,7 +137,6 @@ export class OcrAppStack extends cdk.Stack {
       userPoolClientId: auth.client.userPoolClientId,
       apiUrl: api.apiEndpoint,
       enableOcr: p.enableOcr,
-      enableAgent: p.enableAgent,
       syncBucketName: api.syncBucket.bucketName,
       webAclArn: props.webAclArn,
       websocketUrl: websocket.apiEndpoint,

--- a/lib/parameters.ts
+++ b/lib/parameters.ts
@@ -22,7 +22,6 @@ export interface AppParameters {
   marketplaceModelPackageArn?: string;
 
   // Agent
-  enableAgent: boolean;
   enableAgentDemo: boolean;
 
   // Cognito
@@ -56,7 +55,6 @@ const defaultParameters: AppParameters = {
   ocrEngine: "paddle",
   sagemakerZeroScale: true,
   sagemakerScaleInCooldownSeconds: 3600,
-  enableAgent: true,
   enableAgentDemo: true,
   selfSignUpEnabled: true,
   allowedSignUpEmailDomains: [],

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -2,9 +2,6 @@
 export const APP_CONFIG = {
   // OCRモードの設定
   enableOcr: import.meta.env.VITE_ENABLE_OCR === 'true',
-  
-  // Agentモードの設定
-  enableAgent: import.meta.env.VITE_ENABLE_AGENT === 'true',
 
   // その他の設定
   userPoolClientId: import.meta.env.VITE_APP_USER_POOL_CLIENT_ID,
@@ -15,6 +12,3 @@ export const APP_CONFIG = {
 
 // OCRモードのチェック関数
 export const isOcrEnabled = () => APP_CONFIG.enableOcr;
-
-// Agentモードのチェック関数
-export const isAgentEnabled = () => APP_CONFIG.enableAgent;

--- a/web/src/pages/ocr-result/AgentModal.tsx
+++ b/web/src/pages/ocr-result/AgentModal.tsx
@@ -61,7 +61,7 @@ export default function AgentModal({ isOpen, onClose, tools, onRunAgent, agentSt
           variant="primary"
           size="sm"
           onClick={handleExecute}
-          disabled={running || tools.length === 0}
+          disabled={running}
         >
           {running ? '検証中...' : '検証実行'}
         </Button>

--- a/web/src/pages/ocr-result/OCRResult.tsx
+++ b/web/src/pages/ocr-result/OCRResult.tsx
@@ -1102,10 +1102,10 @@ function OcrResult() {
                   </>
                 ) : (
                   <>
-                    <Button variant="outline" size="sm" onClick={() => { suggestionsSnapshotRef.current = [...agentSuggestions]; extractedInfoSnapshotRef.current = { ...extractedInfo }; setEditMode(true); }}>
+                    <Button variant="outline" size="sm" disabled={agentStatus === 'running'} onClick={() => { suggestionsSnapshotRef.current = [...agentSuggestions]; extractedInfoSnapshotRef.current = { ...extractedInfo }; setEditMode(true); }}>
                       <Pencil size={14} className="mr-1" />編集
                     </Button>
-                    <Button variant="outline" size="sm" onClick={handleReExtract} disabled={loading}>
+                    <Button variant="outline" size="sm" onClick={handleReExtract} disabled={loading || agentStatus === 'running'}>
                       <RefreshCw size={14} className="mr-1" />抽出設定
                     </Button>
                     {agentEnabled && (
@@ -1193,7 +1193,7 @@ function OcrResult() {
                     agentSuggestions={agentSuggestions}
                     onAcceptSuggestion={handleAcceptSuggestion}
                     onRejectSuggestion={handleRejectSuggestion}
-                    onEnterEditMode={() => { suggestionsSnapshotRef.current = [...agentSuggestions]; extractedInfoSnapshotRef.current = { ...extractedInfo }; setEditMode(true); }}
+                    onEnterEditMode={() => { if (agentStatus === 'running') return; suggestionsSnapshotRef.current = [...agentSuggestions]; extractedInfoSnapshotRef.current = { ...extractedInfo }; setEditMode(true); }}
                   />
                 </>
               )}

--- a/web/src/pages/ocr-result/OCRResult.tsx
+++ b/web/src/pages/ocr-result/OCRResult.tsx
@@ -6,9 +6,9 @@ import { runAgent as apiRunAgent, getAgentToolsForImage, getAgentJobByImage, pol
 import { updateVerificationStatus } from "../../services/imageApi";
 import { OcrWord, OcrBoundingBox, OcrResponse, PresignedDownloadUrlResponse } from "../../types/ocr";
 import { ExtractionResponse, ExtractionMapping } from "../../types/extraction";
-import { Field } from "../../types/app-schema";
+import { Field, AppSchema } from "../../types/app-schema";
 import { Suggestion, Tool } from "../../types/agent";
-import { isOcrEnabled, isAgentEnabled } from "../../config";
+import { isOcrEnabled } from "../../config";
 import { usePresence } from "../../hooks/usePresence";
 import PresenceBadge from "../../components/shared/PresenceBadge";
 import ImagePreview from "./ImagePreview";
@@ -61,6 +61,7 @@ function OcrResult() {
   const [appFields, setAppFields] = useState<Field[]>([]);
   const [editMode, setEditMode] = useState(false);
   const [appName, setAppName] = useState<string>("");
+  const [agentEnabled, setAgentEnabled] = useState(false);
   const [mapping, setMapping] = useState<ExtractionMapping>({});
   const [pollingAttemptCount, setPollingAttemptCount] = useState(0);
   const [activeView, setActiveView] = useState<"ocr" | "extraction">(
@@ -355,6 +356,15 @@ function OcrResult() {
       setLoading(false);
     }
   }, [id]);
+
+  // エージェント検証はユースケース単位の agent_enabled で有効化する
+  useEffect(() => {
+    if (!appName) return;
+    api
+      .get<AppSchema>(`/apps/${appName}`)
+      .then((res) => setAgentEnabled(res.data.agent_enabled ?? false))
+      .catch(() => setAgentEnabled(false));
+  }, [appName]);
 
   // 抽出情報の取得
   const fetchExtractionInfo = async () => {
@@ -977,7 +987,7 @@ function OcrResult() {
       />
 
       {/* エージェント検証モーダル */}
-      {isAgentEnabled() && (
+      {agentEnabled && (
         <AgentModal
           isOpen={showAgentModal}
           onClose={() => setShowAgentModal(false)}
@@ -1098,7 +1108,7 @@ function OcrResult() {
                     <Button variant="outline" size="sm" onClick={handleReExtract} disabled={loading}>
                       <RefreshCw size={14} className="mr-1" />抽出設定
                     </Button>
-                    {isAgentEnabled() && (
+                    {agentEnabled && (
                       <Button variant="outline" size="sm" onClick={() => setShowAgentModal(true)} disabled={agentStatus === 'running'}>
                         <Bot size={14} className="mr-1" />エージェント検証
                       </Button>

--- a/web/src/pages/schema/SchemaGenerator.tsx
+++ b/web/src/pages/schema/SchemaGenerator.tsx
@@ -70,6 +70,7 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
 
   // エージェント設定
   const [agentEnabled, setAgentEnabled] = useState(false);
+  const [agentAutoRun, setAgentAutoRun] = useState(false);
   const [usecaseTools, setUsecaseTools] = useState<any[]>([]);
   const [availableTools, setAvailableTools] = useState<any[]>([]);
 
@@ -100,6 +101,7 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
 
           // エージェント設定を復元
           setAgentEnabled(appData.agent_enabled || false);
+          setAgentAutoRun(appData.agent_auto_run || false);
         })
         .catch((err) => {
           setError(`スキーマの読み込みに失敗しました: ${err?.userMessage ?? err?.message ?? "不明なエラー"}`);
@@ -391,6 +393,7 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
         description: appDescription,
         input_methods: inputMethods,
         agent_enabled: agentEnabled,
+        agent_auto_run: agentEnabled && agentAutoRun,
         // 生成指示プロンプトも保存し、編集画面で復元できるようにする
         schema_instructions: extractionInstructions || "",
       };
@@ -625,9 +628,27 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
                       htmlFor="agentEnabled"
                       className="ml-2 block text-sm text-neutral-900"
                     >
-                      抽出後にエージェント検証を自動実行
+                      エージェント検証を有効にする
                     </label>
                   </div>
+                  {agentEnabled && (
+                    <div className="flex items-center pl-6">
+                      <input
+                        type="checkbox"
+                        id="agentAutoRun"
+                        checked={agentAutoRun}
+                        onChange={(e) => setAgentAutoRun(e.target.checked)}
+                        className="h-4 w-4 text-info focus:ring-primary border-neutral-300 rounded"
+                        disabled={isViewMode}
+                      />
+                      <label
+                        htmlFor="agentAutoRun"
+                        className="ml-2 block text-sm text-neutral-900"
+                      >
+                        抽出後に自動実行する
+                      </label>
+                    </div>
+                  )}
                   {agentEnabled && !isEditMode && !isViewMode && (
                     <p className="pl-6 mt-2 text-sm text-neutral-500">
                       ツールの設定は保存後に編集画面で行えます

--- a/web/src/pages/schema/UsecaseSettings.tsx
+++ b/web/src/pages/schema/UsecaseSettings.tsx
@@ -34,6 +34,7 @@ const UsecaseSettings: React.FC<UsecaseSettingsProps> = ({ mode = 'create' }) =>
 
   // エージェント設定
   const [agentEnabled, setAgentEnabled] = useState(false);
+  const [agentAutoRun, setAgentAutoRun] = useState(false);
   const [usecaseTools, setUsecaseTools] = useState<any[]>([]);
   const [availableTools, setAvailableTools] = useState<any[]>([]);
 
@@ -56,6 +57,7 @@ const UsecaseSettings: React.FC<UsecaseSettingsProps> = ({ mode = 'create' }) =>
           }
 
           setAgentEnabled(appData.agent_enabled || false);
+          setAgentAutoRun(appData.agent_auto_run || false);
         })
         .catch((err) => {
           setError(`設定の読み込みに失敗しました: ${err?.userMessage ?? err?.message ?? "不明なエラー"}`);
@@ -118,6 +120,7 @@ const UsecaseSettings: React.FC<UsecaseSettingsProps> = ({ mode = 'create' }) =>
         description: appDescription,
         input_methods: inputMethods,
         agent_enabled: agentEnabled,
+        agent_auto_run: agentEnabled && agentAutoRun,
       };
 
       if (isEditMode && urlAppName) {
@@ -311,9 +314,24 @@ const UsecaseSettings: React.FC<UsecaseSettingsProps> = ({ mode = 'create' }) =>
                     disabled={isViewMode}
                   />
                   <label htmlFor="agentEnabled" className="ml-2 block text-sm text-neutral-900">
-                    抽出後にエージェント検証を自動実行
+                    エージェント検証を有効にする
                   </label>
                 </div>
+                {agentEnabled && (
+                  <div className="flex items-center pl-6">
+                    <input
+                      type="checkbox"
+                      id="agentAutoRun"
+                      checked={agentAutoRun}
+                      onChange={(e) => setAgentAutoRun(e.target.checked)}
+                      className="h-4 w-4 text-info focus:ring-primary border-neutral-300 rounded"
+                      disabled={isViewMode}
+                    />
+                    <label htmlFor="agentAutoRun" className="ml-2 block text-sm text-neutral-900">
+                      抽出後に自動実行する
+                    </label>
+                  </div>
+                )}
                 {agentEnabled && !isEditMode && !isViewMode && (
                   <p className="pl-6 mt-2 text-sm text-neutral-500">
                     ツールの設定は保存後に編集画面で行えます

--- a/web/src/types/app-schema.ts
+++ b/web/src/types/app-schema.ts
@@ -24,6 +24,8 @@ export interface AppSchema {
   permission?: string;
   sample_image_s3_key?: string;
   sample_image_filename?: string;
+  agent_enabled?: boolean;
+  agent_auto_run?: boolean;
 }
 
 export interface S3SyncFile {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Reworks how agent verification is configured and fixes several correctness issues around when the agent runs and how its results are shown.

**1. Remove the global `enableAgent` stack flag**

Previously agent infrastructure was gated by a deploy-time `enableAgent` parameter, which also drove a `VITE_ENABLE_AGENT` build flag used to show/hide agent UI globally. Since agent usage is now controlled per usecase, the global flag was redundant. The agent stack is now always deployed, and the frontend shows agent UI based on the per-usecase setting fetched from the API. AgentCore Runtime and Aurora DSQL are consumption-billed, so always-deploying does not add idle cost.

**2. Split agent verification into two per-usecase flags**

The single `agent_enabled` flag conflated "can this usecase use agent verification" with "auto-run after extraction". These are now separate:
- `agent_enabled` — whether the usecase can use agent verification (gates the manual verify button)
- `agent_auto_run` — whether to run automatically after extraction (only meaningful when enabled)

The usecase settings UI exposes both as nested checkboxes. This is a breaking change to stored schemas (no fallback), which is acceptable as this branch is not yet released.

**3. Allow agent verification without configured tools**

Agent verification previously refused to run when a usecase had no tools assigned (early-return in the service, disabled button in the modal). It now runs LLM-only in that case. Relatedly, the AgentCore runtime no longer treats an empty tool list as "expose all gateway tools" — an empty list means no tools.

**4. Fix agent run gating for manual and re-extract paths**

- Manual verification and auto-run both invoke the same AgentKick worker. The worker now distinguishes them via a `manual` flag: manual runs require only `agent_enabled`, auto runs require `agent_enabled` and `agent_auto_run`. This fixes manual verification being silently skipped on usecases with auto-run disabled.
- On re-extraction, `agent_status` is reset to idle so stale results from a previous verification don't reappear. `GET /images/{id}/agent` returns no job while status is idle. When auto-run is disabled, extraction now completes without any agent involvement.

**5. Lock editing during agent verification**

While agent verification is running, the edit / re-extract entry points on the result screen are disabled to avoid editing extracted values mid-verification.

Verified: backend tests pass, frontend builds, CDK synthesizes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.