### PR TITLE
refactor: centralize worker Lambda async invoke in the clients layer

### DIFF
--- a/lambda/api/app/clients/__init__.py
+++ b/lambda/api/app/clients/__init__.py
@@ -8,6 +8,7 @@ from .aws import (
     create_bedrock_agentcore_client, create_dynamodb_resource, create_sfn_client,
     s3_client, bedrock_client, dynamodb_client, dynamodb_resource,
     sagemaker_runtime_client, sagemaker_client, bedrock_agentcore_client, sfn_client,
+    lambda_client, invoke_worker_async,
     get_inference_component_status, get_endpoint_status_direct, trigger_endpoint_wakeup,
 )
 from .agent import AgentClient
@@ -19,6 +20,7 @@ __all__ = [
     "create_bedrock_agentcore_client", "create_dynamodb_resource", "create_sfn_client",
     "s3_client", "bedrock_client", "dynamodb_client", "dynamodb_resource",
     "sagemaker_runtime_client", "sagemaker_client", "bedrock_agentcore_client", "sfn_client",
+    "lambda_client", "invoke_worker_async",
     "AgentClient",
     "call_bedrock", "call_bedrock_with_retry",
     "get_inference_component_status", "get_endpoint_status_direct", "trigger_endpoint_wakeup",

--- a/lambda/api/app/clients/aws.py
+++ b/lambda/api/app/clients/aws.py
@@ -1,4 +1,5 @@
 """AWS SDK クライアント生成 + グローバルインスタンス"""
+import json
 import boto3
 from botocore.config import Config
 from config import settings
@@ -68,6 +69,11 @@ def create_sfn_client():
     return boto3.client("stepfunctions", region_name=settings.AWS_REGION)
 
 
+def create_lambda_client():
+    """Lambda クライアントを作成（Worker への async invoke 用）"""
+    return boto3.client("lambda", region_name=settings.AWS_REGION)
+
+
 # グローバルインスタンス
 s3_client = create_s3_client()
 bedrock_client = create_bedrock_client()
@@ -77,6 +83,19 @@ sagemaker_runtime_client = create_sagemaker_runtime_client()
 sagemaker_client = create_sagemaker_client()
 bedrock_agentcore_client = create_bedrock_agentcore_client()
 sfn_client = create_sfn_client()
+lambda_client = create_lambda_client()
+
+
+def invoke_worker_async(function_name: str, payload: dict) -> None:
+    """Worker Lambda を非同期（InvocationType="Event"）で起動する。
+
+    単発 fire-and-forget の Worker 起動を1箇所に集約する。
+    """
+    lambda_client.invoke(
+        FunctionName=function_name,
+        InvocationType="Event",
+        Payload=json.dumps(payload),
+    )
 
 
 def get_inference_component_status(component_name: str) -> dict:

--- a/lambda/api/app/services/agent_service.py
+++ b/lambda/api/app/services/agent_service.py
@@ -8,13 +8,11 @@ from exceptions import NotFoundError
 from repositories.job_repository import JobStatus, SuggestionStatus
 from typing import Dict, Any
 
-import boto3
-
 from repositories import get_image, update_agent_status
 from repositories.job_repository import create_agent_job, update_agent_job, get_job
 from repositories.tool_repository import list_tools, get_usecase_allowed_tool_names, get_usecase_tools
 from repositories.usecase_repository import get_usecase_by_app_name
-from clients import AgentClient, s3_client
+from clients import AgentClient, s3_client, invoke_worker_async
 from config import settings
 logger = logging.getLogger(__name__)
 
@@ -42,12 +40,9 @@ class AgentService:
             update_agent_status(image_id, AgentStatus.PROCESSING, suggestions_count=0)
 
             # Invoke AgentKick Lambda asynchronously
-            lambda_client = boto3.client("lambda")
-            lambda_client.invoke(
-                FunctionName=settings.AGENT_KICK_FUNCTION_NAME,
-                InvocationType="Event",  # async
-                Payload=json.dumps({"image_id": image_id, "job_id": job_id, "manual": True}),
-            )
+            invoke_worker_async(settings.AGENT_KICK_FUNCTION_NAME, {
+                "image_id": image_id, "job_id": job_id, "manual": True,
+            })
             logger.info(f"Invoked AgentKick Lambda for job {job_id}")
 
             return job_id

--- a/lambda/api/app/services/s3_sync_service.py
+++ b/lambda/api/app/services/s3_sync_service.py
@@ -1,6 +1,4 @@
-from clients import s3_client
-import boto3
-import json
+from clients import s3_client, invoke_worker_async
 import logging
 import uuid
 from datetime import datetime
@@ -119,15 +117,11 @@ class S3SyncService:
 
         if items:
             try:
-                boto3.client("lambda").invoke(
-                    FunctionName=settings.S3_SYNC_IMPORT_FUNCTION_NAME,
-                    InvocationType="Event",
-                    Payload=json.dumps({
-                        "app_name": app_name,
-                        "page_processing_mode": page_processing_mode,
-                        "items": items,
-                    }),
-                )
+                invoke_worker_async(settings.S3_SYNC_IMPORT_FUNCTION_NAME, {
+                    "app_name": app_name,
+                    "page_processing_mode": page_processing_mode,
+                    "items": items,
+                })
             except Exception:
                 # invoke 失敗時は作成済みレコードを FAILED にし、UPLOADING のまま残さない
                 for image_id in created_image_ids:

--- a/lambda/api/app/services/schema_service.py
+++ b/lambda/api/app/services/schema_service.py
@@ -1,6 +1,4 @@
-from clients import s3_client
-import boto3
-import json
+from clients import s3_client, invoke_worker_async
 import logging
 import os
 import uuid
@@ -356,17 +354,12 @@ class SchemaService:
             logger.info(f"Created schema generation job: {job_id}")
 
             # 2. Worker Lambda を async invoke
-            lambda_client = boto3.client("lambda")
-            lambda_client.invoke(
-                FunctionName=settings.SCHEMA_GENERATE_FUNCTION_NAME,
-                InvocationType="Event",  # async
-                Payload=json.dumps({
-                    "job_id": job_id,
-                    "s3_key": request.s3_key,
-                    "filename": request.filename,
-                    "instructions": request.instructions or "",
-                }),
-            )
+            invoke_worker_async(settings.SCHEMA_GENERATE_FUNCTION_NAME, {
+                "job_id": job_id,
+                "s3_key": request.s3_key,
+                "filename": request.filename,
+                "instructions": request.instructions or "",
+            })
             logger.info(f"Invoked SchemaGenerate Lambda for job {job_id}")
 
             return {"job_id": job_id, "status": "processing"}

--- a/lambda/api/app/services/upload_service.py
+++ b/lambda/api/app/services/upload_service.py
@@ -1,6 +1,4 @@
-from clients import s3_client
-import boto3
-import json
+from clients import s3_client, invoke_worker_async
 import uuid
 import logging
 from datetime import datetime
@@ -186,15 +184,10 @@ class UploadService:
 
             # 変換は Worker Lambda に async invoke で委譲する。
             # HTTP 応答後の実行環境回収で変換が失われないよう API 内スレッドでは行わない。
-            lambda_client = boto3.client("lambda")
-            lambda_client.invoke(
-                FunctionName=settings.PDF_CONVERT_FUNCTION_NAME,
-                InvocationType="Event",
-                Payload=json.dumps({
-                    "image_id": image_id,
-                    "s3_key": request.s3_key,
-                }),
-            )
+            invoke_worker_async(settings.PDF_CONVERT_FUNCTION_NAME, {
+                "image_id": image_id,
+                "s3_key": request.s3_key,
+            })
             logger.info(f"Invoked PdfConvert Lambda for image {image_id}")
 
             return {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Four services (upload, schema generation, agent, S3 sync import) each called `boto3.client("lambda").invoke(..., InvocationType="Event", ...)` inline with verbatim-duplicated code. This both duplicated the pattern and bypassed the `clients/` layer that centralizes every other AWS client (s3, dynamodb, sfn, sagemaker, bedrock).

This change adds a `lambda_client` and an `invoke_worker_async(function_name, payload)` helper to `clients/aws.py` (exported from `clients`), matching the existing client pattern, and updates the four services to call it. Behavior is unchanged; retries/logging/metrics can now be added in one place.

Verified: backend tests pass, no service references boto3 directly for Lambda.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.