### PR TITLE
perf: split the frontend bundle and fix re-render issues

### DIFF
--- a/web/src/components/layout/AppLayout.tsx
+++ b/web/src/components/layout/AppLayout.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import { Outlet, Link, useParams } from 'react-router-dom';
 import { useAppContext } from '../../contexts/AppContext';
 import { UserMenu } from './UserMenu';
@@ -32,7 +33,9 @@ export function AppLayout() {
       <div className="flex flex-grow">
         <Sidebar />
         <main className="flex-grow overflow-auto">
-          <Outlet />
+          <Suspense fallback={<div className="flex justify-center items-center h-full py-20"><div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-info" /></div>}>
+            <Outlet />
+          </Suspense>
         </main>
       </div>
     </div>

--- a/web/src/pages/ocr-result/OCRResult.tsx
+++ b/web/src/pages/ocr-result/OCRResult.tsx
@@ -37,6 +37,12 @@ const styles = {
   scrollContainerStyle: { maxHeight: "calc(100vh - 200px)" },
 };
 
+const LoadingSpinner = () => (
+  <div className={styles.loadingContainer}>
+    <div className={styles.spinner}></div>
+  </div>
+);
+
 function OcrResult() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -955,13 +961,6 @@ function OcrResult() {
 
   // 表示タイトル
   const currentViewTitle = activeView === "ocr" ? "OCR結果" : "抽出結果";
-
-  // ローディングスピナーコンポーネント
-  const LoadingSpinner = () => (
-    <div className={styles.loadingContainer}>
-      <div className={styles.spinner}></div>
-    </div>
-  );
 
   return (
     <div className={styles.container}>

--- a/web/src/pages/schema/SchemaGenerator.tsx
+++ b/web/src/pages/schema/SchemaGenerator.tsx
@@ -31,10 +31,10 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { refreshApps, apps, appsLoaded, isAdmin } = useAppContext();
   
-  // モード関連の状態
-  const [isViewMode] = useState(mode === 'view');
-  const [isEditMode] = useState(mode === 'edit');
-  const [isCreateMode] = useState(mode === 'create');
+  // モードは prop から導出する（不変なので state に持たない）
+  const isViewMode = mode === 'view';
+  const isEditMode = mode === 'edit';
+  const isCreateMode = mode === 'create';
   const [isLoading, setIsLoading] = useState(false);
 
   const [appName, setAppName] = useState("");

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,15 +1,18 @@
 import { createBrowserRouter } from 'react-router-dom';
+import { lazy } from 'react';
 import { AuthWrapper } from './components/layout/AuthWrapper';
 import { AppLayout } from './components/layout/AppLayout';
 import { AppProvider } from './contexts/AppContext';
-import Home from './pages/Home';
-import Stars from './pages/Stars';
-import History from './pages/History';
-import Upload from './pages/upload/Upload';
-import OCRResult from './pages/ocr-result/OCRResult';
-import SchemaGenerator from './pages/schema/SchemaGenerator';
-import Admin from './pages/Admin';
-import NotFound from './pages/NotFound';
+
+// ルート単位でコード分割し、初回ロードの単一巨大チャンクを避ける。
+const Home = lazy(() => import('./pages/Home'));
+const Stars = lazy(() => import('./pages/Stars'));
+const History = lazy(() => import('./pages/History'));
+const Upload = lazy(() => import('./pages/upload/Upload'));
+const OCRResult = lazy(() => import('./pages/ocr-result/OCRResult'));
+const SchemaGenerator = lazy(() => import('./pages/schema/SchemaGenerator'));
+const Admin = lazy(() => import('./pages/Admin'));
+const NotFound = lazy(() => import('./pages/NotFound'));
 
 const Root = () => (
   <AuthWrapper>

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -16,4 +16,17 @@ export default defineConfig({
     // Allow all hosts for remote development environments accessed via proxy
     allowedHosts: true,
   },
+  build: {
+    rollupOptions: {
+      output: {
+        // 変更頻度の低い大きめの依存を分離し、アプリ更新時の再ダウンロードを避ける。
+        manualChunks: (id) => {
+          if (id.includes('node_modules')) {
+            if (id.includes('aws-amplify') || id.includes('@aws-amplify')) return 'amplify-vendor';
+            if (id.includes('react-dom') || id.includes('react-router') || id.includes('/react/')) return 'react-vendor';
+          }
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

The frontend built into a single ~927KB JS chunk (Vite warned about the >500KB chunk) because every page was imported statically. This PR splits the bundle and fixes a couple of re-render correctness issues found via the React best-practices guidelines.

**Bundle splitting**
- Lazy-load page routes with `React.lazy` and a `Suspense` boundary around the router `Outlet` (chrome stays, only the routed page suspends). Each page (OCRResult, Upload, Admin, SchemaGenerator, etc.) now emits its own chunk and loads on demand.
- Split vendor into `react-vendor` and `amplify-vendor` via `manualChunks` so the large, rarely-changing dependencies cache separately and the >500KB warning is gone.
- Result: the eager app chunk drops from ~927KB to ~58KB, with React/Amplify and each page in separate cacheable chunks.

**Re-render fixes (React best-practices)**
- `OCRResult`: hoist `LoadingSpinner` out of the component. Defining it inline created a new component type every render, remounting it (rule: don't define components inside components).
- `SchemaGenerator`: derive `isViewMode`/`isEditMode`/`isCreateMode` from the `mode` prop during render instead of storing them in `useState` (rule: calculate derived state during rendering).

Verified: type-checks and builds; chunks split as expected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.