### PR TITLE
refactor: extract admin tab data fetching into a useFetch hook

### DIFF
--- a/web/src/hooks/useFetch.ts
+++ b/web/src/hooks/useFetch.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState, useCallback } from 'react';
+
+/**
+ * マウント時に fetcher を実行し、loading 状態と再取得手段を提供する共通フック。
+ *
+ * 各画面で散在していた「data/loading の useState + load の useCallback + useEffect」
+ * の定型を一元化する。fetcher は表示用データを返す（一覧の抽出やソート等の整形は
+ * 呼び出し側で行い、その結果を data にセットする）。
+ *
+ * @param fetcher 表示用データを返す非同期関数（安定参照を渡すこと）
+ * @param initial data の初期値
+ */
+export function useFetch<T>(fetcher: () => Promise<T>, initial: T) {
+  const [data, setData] = useState<T>(initial);
+  const [loading, setLoading] = useState(true);
+
+  const refetch = useCallback(async () => {
+    setLoading(true);
+    try {
+      setData(await fetcher());
+    } finally {
+      setLoading(false);
+    }
+  }, [fetcher]);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  return { data, loading, refetch };
+}

--- a/web/src/pages/admin/GroupsTab.tsx
+++ b/web/src/pages/admin/GroupsTab.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Users, Trash2, Plus, X, Search, User } from 'lucide-react';
 import { Button, Table, Thead, Tbody, Badge, Modal, Input, usePagination, Pagination, SearchBox, CardTable, EmptyState, TableSkeleton } from '../../components/ui';
+import { useFetch } from '../../hooks/useFetch';
 import * as adminApi from '../../services/adminApi';
 import api from '../../services/api';
 import { AdminToolbar } from './AdminToolbar';
@@ -10,8 +11,6 @@ import type { GroupMember, SearchUser } from '../../types/user';
 const MEMBER_PAGE_SIZE = 10;
 
 export default function GroupsTab() {
-  const [groups, setGroups] = useState<Group[]>([]);
-  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState('');
@@ -26,15 +25,8 @@ export default function GroupsTab() {
   const [addSearch, setAddSearch] = useState('');
   const [addResults, setAddResults] = useState<SearchUser[]>([]);
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    try {
-      const data = await adminApi.getGroups();
-      setGroups(data.groups || []);
-    } finally { setLoading(false); }
-  }, []);
-
-  useEffect(() => { load(); }, [load]);
+  const fetchGroups = useCallback(async () => (await adminApi.getGroups()).groups || [], []);
+  const { data: groups, loading, refetch: load } = useFetch<Group[]>(fetchGroups, []);
 
   const visible = useMemo(() => groups.filter((g) => g.source !== 'auto'), [groups]);
   const filtered = useMemo(() => {

--- a/web/src/pages/admin/ImagesTab.tsx
+++ b/web/src/pages/admin/ImagesTab.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Image, CheckCircle } from 'lucide-react';
 import { Table, Thead, Tbody, usePagination, Pagination, SearchBox, CardTable, EmptyState, TableSkeleton, Tooltip } from '../../components/ui';
+import { useFetch } from '../../hooks/useFetch';
 import ProcessStatusBadge from '../../components/shared/ProcessStatusBadge';
 import PresenceBadge from '../../components/shared/PresenceBadge';
 import { usePresence, PRESENCE_LIST_MODE } from '../../hooks/usePresence';
@@ -26,22 +27,18 @@ export default function ImagesTab() {
   const navigate = useNavigate();
   const { apps } = useAppContext();
   const { byImageId: presenceByImageId } = usePresence({ imageId: PRESENCE_LIST_MODE });
-  const [images, setImages] = useState<AdminImage[]>([]);
-  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [appFilter, setAppFilter] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
   const [verificationFilter, setVerificationFilter] = useState('');
 
-  useEffect(() => {
-    adminApi.getAllImages().then((data) => {
-      const list: AdminImage[] = (data.images || []).sort((a: AdminImage, b: AdminImage) =>
-        (b.uploadTime || '').localeCompare(a.uploadTime || '')
-      );
-      setImages(list);
-      setLoading(false);
-    });
+  const fetchImages = useCallback(async (): Promise<AdminImage[]> => {
+    const data = await adminApi.getAllImages();
+    return (data.images || []).sort((a: AdminImage, b: AdminImage) =>
+      (b.uploadTime || '').localeCompare(a.uploadTime || '')
+    );
   }, []);
+  const { data: images, loading } = useFetch<AdminImage[]>(fetchImages, []);
 
   const appNames = useMemo(() => [...new Set(images.map((i) => i.appName).filter(Boolean))], [images]);
 

--- a/web/src/pages/admin/ToolsTab.tsx
+++ b/web/src/pages/admin/ToolsTab.tsx
@@ -1,30 +1,20 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { Wrench } from 'lucide-react';
 import { Button, Table, Thead, Tbody, Toggle, usePagination, Pagination, SearchBox, CardTable, EmptyState, TableSkeleton } from '../../components/ui';
+import { useFetch } from '../../hooks/useFetch';
 import * as adminApi from '../../services/adminApi';
 import { PermissionModal } from '../../components/shared/PermissionModal';
 import { AdminToolbar } from './AdminToolbar';
 import type { ManagedTool, ToolPermissions } from '../../types/tool';
 
 export default function ToolsTab() {
-  const [tools, setTools] = useState<ManagedTool[]>([]);
-  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [selectedTool, setSelectedTool] = useState<ManagedTool | null>(null);
   const [perms, setPerms] = useState<ToolPermissions>({ users: [], groups: [], usecases: [] });
   const [isPublic, setIsPublic] = useState(false);
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    try {
-      const data = await adminApi.getTools();
-      setTools(data.tools || []);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => { load(); }, [load]);
+  const fetchTools = useCallback(async () => (await adminApi.getTools()).tools || [], []);
+  const { data: tools, loading, refetch: load } = useFetch<ManagedTool[]>(fetchTools, []);
 
   const filtered = useMemo(() => {
     if (!search) return tools;
@@ -39,7 +29,8 @@ export default function ToolsTab() {
       await adminApi.updateTool(tool.id, { is_active: !tool.is_active });
       await load();
     } catch {
-      setTools((prev) => prev.map((t) => t.id === tool.id ? { ...t, is_active: !t.is_active } : t));
+      // 失敗時は一覧を再取得して実際の状態に戻す
+      await load();
     }
   };
 

--- a/web/src/pages/admin/UsecasesTab.tsx
+++ b/web/src/pages/admin/UsecasesTab.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { Layers } from 'lucide-react';
 import { Table, Thead, Tbody, Button, usePagination, Pagination, SearchBox, CardTable, EmptyState, TableSkeleton } from '../../components/ui';
 import api from '../../services/api';
+import { useFetch } from '../../hooks/useFetch';
 import * as adminApi from '../../services/adminApi';
 import { PermissionModal } from '../../components/shared/PermissionModal';
 import { AdminToolbar } from './AdminToolbar';
@@ -19,19 +20,13 @@ const GROUP_PERM_LEVELS = [
 ];
 
 export default function UsecasesTab() {
-  const [usecases, setUsecases] = useState<Usecase[]>([]);
-  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [selected, setSelected] = useState<Usecase | null>(null);
   const [perms, setPerms] = useState<{ users: UsecaseUserPermission[]; groups: UsecaseGroupPermission[] }>({ users: [], groups: [] });
   const [isPublic, setIsPublic] = useState(false);
 
-  useEffect(() => {
-    adminApi.getUsecases().then((data) => {
-      setUsecases(data.usecases || []);
-      setLoading(false);
-    });
-  }, []);
+  const fetchUsecases = useCallback(async () => (await adminApi.getUsecases()).usecases || [], []);
+  const { data: usecases, loading } = useFetch<Usecase[]>(fetchUsecases, []);
 
   const filtered = useMemo(() => {
     if (!search) return usecases;

--- a/web/src/pages/admin/UsersTab.tsx
+++ b/web/src/pages/admin/UsersTab.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { Users } from 'lucide-react';
 import { Table, Thead, Tbody, Badge, usePagination, Pagination, SearchBox, CardTable, EmptyState, TableSkeleton } from '../../components/ui';
+import { useFetch } from '../../hooks/useFetch';
 import * as adminApi from '../../services/adminApi';
 import { AdminToolbar } from './AdminToolbar';
 import type { User } from '../../types/user';
@@ -20,23 +21,12 @@ const ROLE_BADGE_COLOR = {
 } as const;
 
 export default function UsersTab() {
-  const [users, setUsers] = useState<User[]>([]);
-  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [roleFilter, setRoleFilter] = useState('');
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    try {
-      const data = await adminApi.getUsers();
-      setUsers(data.users || []);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => { load(); }, [load]);
+  const fetchUsers = useCallback(async () => (await adminApi.getUsers()).users || [], []);
+  const { data: users, loading, refetch } = useFetch<User[]>(fetchUsers, []);
 
   const filtered = useMemo(() => {
     return users.filter((u) => {
@@ -51,9 +41,7 @@ export default function UsersTab() {
 
   const { page, setPage, total, paged, pageSize, changePageSize, totalItems } = usePagination(filtered);
 
-  const handleUpdated = (userId: string, newRole: string) => {
-    setUsers(prev => prev.map(u => u.id === userId ? { ...u, role: newRole } : u));
-  };
+  const handleUpdated = () => { refetch(); };
 
   if (loading) return <TableSkeleton rows={5} cols={5} />;
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

The five admin tabs (Users, Groups, Tools, Usecases, Images) each repeated the same "data + loading useState, a load callback that toggles loading around a fetch, and a useEffect to run it on mount" boilerplate.

This extracts a small `useFetch(fetcher, initial)` hook returning `{ data, loading, refetch }` and updates all five tabs to use it. Each tab passes a stable (useCallback) fetcher that returns the display list (extraction/sort stays at the call site). Tabs that re-fetched after a mutation now use `refetch`; UsersTab/ToolsTab which previously did an optimistic local mutation or rollback now refetch instead (equivalent result, simpler).

Verified: type-checks and builds; no tab references the removed local setters.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.