### PR TITLE
refactor: type remaining useState<any>; fix usecase owners missing id

### DIFF
--- a/lambda/api/app/repositories/usecase_repository.py
+++ b/lambda/api/app/repositories/usecase_repository.py
@@ -35,7 +35,7 @@ def list_usecases() -> list[dict]:
 def get_usecase_owners(usecase_id: str) -> list[dict]:
     """ユースケースの owner 一覧"""
     rows = query("""
-        SELECT u.email FROM user_usecases uu
+        SELECT u.id, u.email, u.display_name FROM user_usecases uu
         JOIN users u ON uu.user_id = u.id
         WHERE uu.usecase_id = %s AND uu.permission = 'owner'
         ORDER BY u.email

--- a/web/src/components/shared/PermissionModal.tsx
+++ b/web/src/components/shared/PermissionModal.tsx
@@ -4,20 +4,20 @@ import { Button, Badge, Modal } from '../ui';
 import api from '../../services/api';
 import type { SearchResult } from '../../types/group';
 
-interface PermissionUser {
+export interface PermissionUser {
   id: string;
   email: string;
   display_name?: string;
   permission?: string;
 }
 
-interface PermissionGroup {
+export interface PermissionGroup {
   id: string;
   name: string;
   permission?: string;
 }
 
-interface Owner {
+export interface Owner {
   id: string;
   email: string;
   display_name?: string;

--- a/web/src/pages/ocr-result/OCRResult.tsx
+++ b/web/src/pages/ocr-result/OCRResult.tsx
@@ -7,7 +7,7 @@ import { updateVerificationStatus } from "../../services/imageApi";
 import { OcrWord, OcrBoundingBox, OcrResponse, PresignedDownloadUrlResponse } from "../../types/ocr";
 import { ExtractionResponse, ExtractionMapping } from "../../types/extraction";
 import { Field, AppSchema } from "../../types/app-schema";
-import { Suggestion, Tool } from "../../types/agent";
+import { Suggestion, Tool, AgentJobResponse } from "../../types/agent";
 import { isOcrEnabled } from "../../config";
 import { usePresence } from "../../hooks/usePresence";
 import PresenceBadge from "../../components/shared/PresenceBadge";
@@ -90,7 +90,7 @@ function OcrResult() {
     type: 'success'
   });
   const [agentStatus, setAgentStatus] = useState<'idle' | 'running' | 'completed'>('idle');
-  const [initialAgentResult, setInitialAgentResult] = useState<any>(null);
+  const [initialAgentResult, setInitialAgentResult] = useState<AgentJobResponse | null>(null);
   const [agentSuggestions, setAgentSuggestions] = useState<Suggestion[]>([]);
   const [pendingSuggestionActions, setPendingSuggestionActions] = useState<{ index: number; status: 'accepted' | 'rejected' }[]>([]);
   const suggestionsSnapshotRef = useRef<Suggestion[]>([]);

--- a/web/src/pages/schema/SchemaGenerator.tsx
+++ b/web/src/pages/schema/SchemaGenerator.tsx
@@ -4,6 +4,7 @@ import { Info } from "lucide-react";
 import SchemaPreview from "./SchemaPreview";
 import SchemaFieldsEditor from "./SchemaFieldsEditor";
 import { Field } from "../../types/app-schema";
+import { Tool } from "../../types/agent";
 import api from "../../services/api";
 import { validateSchemaFields, isValidAppName } from "../../utils/schemaValidation";
 import { useAppContext } from "../../contexts/AppContext";
@@ -71,8 +72,8 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
   // エージェント設定
   const [agentEnabled, setAgentEnabled] = useState(false);
   const [agentAutoRun, setAgentAutoRun] = useState(false);
-  const [usecaseTools, setUsecaseTools] = useState<any[]>([]);
-  const [availableTools, setAvailableTools] = useState<any[]>([]);
+  const [usecaseTools, setUsecaseTools] = useState<Tool[]>([]);
+  const [availableTools, setAvailableTools] = useState<Tool[]>([]);
 
   // 既存のスキーマを読み込む（編集・閲覧モード）
   useEffect(() => {
@@ -659,7 +660,7 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
                           <p className="text-sm text-muted mb-2">割当済みツール:</p>
                           {usecaseTools.length > 0 ? (
                             <div className="space-y-1">
-                              {usecaseTools.map((tool: any) => (
+                              {usecaseTools.map((tool) => (
                                 <div key={tool.id} className="text-sm px-2 py-1 bg-surface rounded">
                                   <span className="font-medium">{tool.name}</span>
                                   {tool.description && (
@@ -678,17 +679,17 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
                           <div>
                             <p className="text-sm font-medium text-muted mb-2">割当済みツール</p>
                             <div className="border border-default rounded-lg p-2 min-h-[100px] space-y-1">
-                              {usecaseTools.length > 0 ? usecaseTools.map((tool: any) => (
+                              {usecaseTools.length > 0 ? usecaseTools.map((tool) => (
                                 <div key={tool.id} className="text-sm px-2 py-1.5 bg-surface rounded">
                                   <div className="flex justify-between items-center">
                                     <span className="font-medium">{tool.name}</span>
                                     <button
                                       onClick={() => {
                                         const prev = usecaseTools;
-                                        const updated = usecaseTools.filter((t: any) => t.id !== tool.id);
+                                        const updated = usecaseTools.filter((t) => t.id !== tool.id);
                                         setUsecaseTools(updated);
                                         api.put(`/apps/${urlAppName}/tools`, {
-                                          tool_ids: updated.map((t: any) => t.id),
+                                          tool_ids: updated.map((t) => t.id),
                                         }).catch((err: any) => {
                                           setUsecaseTools(prev);
                                           setError(`ツール解除に失敗しました: ${err?.userMessage ?? err?.message ?? "不明なエラー"}`);
@@ -714,8 +715,8 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
                             <p className="text-sm font-medium text-muted mb-2">追加可能なツール</p>
                             <div className="border border-default rounded-lg p-2 min-h-[100px] space-y-1">
                               {availableTools
-                                .filter((t: any) => !usecaseTools.find((ut: any) => ut.id === t.id))
-                                .map((tool: any) => (
+                                .filter((t) => !usecaseTools.find((ut) => ut.id === t.id))
+                                .map((tool) => (
                                   <div key={tool.id} className="text-sm px-2 py-1.5 bg-surface rounded">
                                     <div className="flex justify-between items-center">
                                       <span className="font-medium">{tool.name}</span>
@@ -725,7 +726,7 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
                                           const updated = [...usecaseTools, tool];
                                           setUsecaseTools(updated);
                                           api.put(`/apps/${urlAppName}/tools`, {
-                                            tool_ids: updated.map((t: any) => t.id),
+                                            tool_ids: updated.map((t) => t.id),
                                           }).catch((err: any) => {
                                             setUsecaseTools(prev);
                                             setError(`ツール追加に失敗しました: ${err?.userMessage ?? err?.message ?? "不明なエラー"}`);
@@ -742,7 +743,7 @@ const SchemaGenerator: React.FC<SchemaGeneratorProps> = ({ mode = 'create' }) =>
                                     )}
                                   </div>
                                 ))}
-                              {availableTools.filter((t: any) => !usecaseTools.find((ut: any) => ut.id === t.id)).length === 0 && (
+                              {availableTools.filter((t) => !usecaseTools.find((ut) => ut.id === t.id)).length === 0 && (
                                 <p className="text-xs text-muted p-2">追加可能なツールはありません</p>
                               )}
                             </div>

--- a/web/src/pages/schema/UsecaseSettings.tsx
+++ b/web/src/pages/schema/UsecaseSettings.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Info } from "lucide-react";
 import api from "../../services/api";
+import { Tool } from "../../types/agent";
 import { useAppContext } from "../../contexts/AppContext";
 import { Alert, Button, Skeleton } from "../../components/ui";
 
@@ -35,8 +36,8 @@ const UsecaseSettings: React.FC<UsecaseSettingsProps> = ({ mode = 'create' }) =>
   // エージェント設定
   const [agentEnabled, setAgentEnabled] = useState(false);
   const [agentAutoRun, setAgentAutoRun] = useState(false);
-  const [usecaseTools, setUsecaseTools] = useState<any[]>([]);
-  const [availableTools, setAvailableTools] = useState<any[]>([]);
+  const [usecaseTools, setUsecaseTools] = useState<Tool[]>([]);
+  const [availableTools, setAvailableTools] = useState<Tool[]>([]);
 
   // 既存のユースケースを読み込む
   useEffect(() => {
@@ -344,7 +345,7 @@ const UsecaseSettings: React.FC<UsecaseSettingsProps> = ({ mode = 'create' }) =>
                         <p className="text-sm text-muted mb-2">割当済みツール:</p>
                         {usecaseTools.length > 0 ? (
                           <div className="space-y-1">
-                            {usecaseTools.map((tool: any) => (
+                            {usecaseTools.map((tool) => (
                               <div key={tool.id} className="text-sm px-2 py-1 bg-surface rounded">
                                 <span className="font-medium">{tool.name}</span>
                                 {tool.description && (
@@ -363,17 +364,17 @@ const UsecaseSettings: React.FC<UsecaseSettingsProps> = ({ mode = 'create' }) =>
                         <div>
                           <p className="text-sm font-medium text-muted mb-2">割当済みツール</p>
                           <div className="border border-default rounded-lg p-2 min-h-[100px] space-y-1">
-                            {usecaseTools.length > 0 ? usecaseTools.map((tool: any) => (
+                            {usecaseTools.length > 0 ? usecaseTools.map((tool) => (
                               <div key={tool.id} className="text-sm px-2 py-1.5 bg-surface rounded">
                                 <div className="flex justify-between items-center">
                                   <span className="font-medium">{tool.name}</span>
                                   <button
                                     onClick={() => {
                                       const prev = usecaseTools;
-                                      const updated = usecaseTools.filter((t: any) => t.id !== tool.id);
+                                      const updated = usecaseTools.filter((t) => t.id !== tool.id);
                                       setUsecaseTools(updated);
                                       api.put(`/apps/${urlAppName}/tools`, {
-                                        tool_ids: updated.map((t: any) => t.id),
+                                        tool_ids: updated.map((t) => t.id),
                                       }).catch((err: any) => {
                                         setUsecaseTools(prev);
                                         setError(`ツール解除に失敗しました: ${err?.userMessage ?? err?.message ?? "不明なエラー"}`);
@@ -399,8 +400,8 @@ const UsecaseSettings: React.FC<UsecaseSettingsProps> = ({ mode = 'create' }) =>
                           <p className="text-sm font-medium text-muted mb-2">追加可能なツール</p>
                           <div className="border border-default rounded-lg p-2 min-h-[100px] space-y-1">
                             {availableTools
-                              .filter((t: any) => !usecaseTools.find((ut: any) => ut.id === t.id))
-                              .map((tool: any) => (
+                              .filter((t) => !usecaseTools.find((ut) => ut.id === t.id))
+                              .map((tool) => (
                                 <div key={tool.id} className="text-sm px-2 py-1.5 bg-surface rounded">
                                   <div className="flex justify-between items-center">
                                     <span className="font-medium">{tool.name}</span>
@@ -410,7 +411,7 @@ const UsecaseSettings: React.FC<UsecaseSettingsProps> = ({ mode = 'create' }) =>
                                         const updated = [...usecaseTools, tool];
                                         setUsecaseTools(updated);
                                         api.put(`/apps/${urlAppName}/tools`, {
-                                          tool_ids: updated.map((t: any) => t.id),
+                                          tool_ids: updated.map((t) => t.id),
                                         }).catch((err: any) => {
                                           setUsecaseTools(prev);
                                           setError(`ツール追加に失敗しました: ${err?.userMessage ?? err?.message ?? "不明なエラー"}`);
@@ -427,7 +428,7 @@ const UsecaseSettings: React.FC<UsecaseSettingsProps> = ({ mode = 'create' }) =>
                                   )}
                                 </div>
                               ))}
-                            {availableTools.filter((t: any) => !usecaseTools.find((ut: any) => ut.id === t.id)).length === 0 && (
+                            {availableTools.filter((t) => !usecaseTools.find((ut) => ut.id === t.id)).length === 0 && (
                               <p className="text-xs text-muted p-2">追加可能なツールはありません</p>
                             )}
                           </div>

--- a/web/src/pages/upload/SharingModal.tsx
+++ b/web/src/pages/upload/SharingModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import api from '../../services/api';
 import { PermissionModal } from '../../components/shared/PermissionModal';
+import type { Owner, PermissionUser, PermissionGroup } from '../../components/shared/PermissionModal';
 
 interface SharingModalProps {
   isOpen: boolean;
@@ -23,9 +24,9 @@ const GROUP_PERM_LEVELS = [
 ];
 
 export default function SharingModal({ isOpen, onClose, appName, appDisplayName, currentUserId, onPermissionLost }: SharingModalProps) {
-  const [owners, setOwners] = useState<any[]>([]);
-  const [users, setUsers] = useState<any[]>([]);
-  const [groups, setGroups] = useState<any[]>([]);
+  const [owners, setOwners] = useState<Owner[]>([]);
+  const [users, setUsers] = useState<PermissionUser[]>([]);
+  const [groups, setGroups] = useState<PermissionGroup[]>([]);
   const [isPublic, setIsPublic] = useState(false);
 
   const loadSharing = async () => {
@@ -35,7 +36,7 @@ export default function SharingModal({ isOpen, onClose, appName, appDisplayName,
       setUsers(r.data.users || []);
       const grps = r.data.groups || [];
       setGroups(grps);
-      setIsPublic(grps.some((g: any) => g.name === 'all'));
+      setIsPublic(grps.some((g: PermissionGroup) => g.name === 'all'));
     } catch {}
   };
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Continues the API-response typing work (following the agent/tool/search typing) by replacing the remaining `useState<any>` that hold API data, and fixes a latent bug the typing surfaced.

**Type the remaining any state**
- `usecaseTools` / `availableTools` (`SchemaGenerator`, `UsecaseSettings`): `any[]` → `Tool[]` (existing type), and dropped the `(tool: any)` / `(t: any)` annotations in the tool list callbacks.
- `initialAgentResult` (`OCRResult`): `any` → `AgentJobResponse | null`.
- `owners` / `users` / `groups` (`SharingModal`): `any[]` → `Owner[]` / `PermissionUser[]` / `PermissionGroup[]`. Those interfaces were internal to `PermissionModal`; they are now exported and reused so both components share one definition.

Each type was checked against the actual backend response shape (the tool/permission/sharing SQL selects), so the types match what is returned.

Remaining `any` left intentionally: `catch (e: any)` and the dynamic extraction result (`Record<string, any>`), which are genuinely dynamic.

**Fix: usecase owners were missing id/display_name**
Typing `owners` as `Owner` exposed a real bug: `get_usecase_owners` only selected `email`, but the frontend uses `owner.id` (to exclude owners from the shared-users filter and as the React key). The owner-exclusion filter was effectively a no-op and the list keys were `undefined`. Added `id` and `display_name` to the select so both work correctly and the data matches the type. Only caller is `sharing_service.get_sharing`.

Verified: backend tests pass (70), frontend type-checks and builds.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.