### PR TITLE
refactor: remove dead code left over from pre-Gateway agentcore implementation

### DIFF
--- a/agentcore/runtime/mcp.json
+++ b/agentcore/runtime/mcp.json
@@ -1,9 +1,0 @@
-{
-  "_comment": "OCR Agent Runtime Configuration",
-  "mcpServers": {
-    "time": {
-      "command": "uvx",
-      "args": ["mcp-server-time"]
-    }
-  }
-}

--- a/agentcore/runtime/src/config.py
+++ b/agentcore/runtime/src/config.py
@@ -29,20 +29,6 @@ def get_aws_credentials() -> dict[str, str]:
     return credentials
 
 
-def get_uv_environment() -> dict[str, str]:
-    """Get UV environment with AWS credentials"""
-    aws_creds = get_aws_credentials()
-    return {
-        "UV_NO_CACHE": "1",
-        "UV_PYTHON": "/usr/local/bin/python",
-        "UV_TOOL_DIR": "/tmp/.uv/tool",
-        "UV_TOOL_BIN_DIR": "/tmp/.uv/tool/bin",
-        "UV_PROJECT_ENVIRONMENT": "/tmp/.venv",
-        "npm_config_cache": "/tmp/.npm",
-        **aws_creds,
-    }
-
-
 def get_system_prompt(user_system_prompt: str = None) -> str:
     """Combine user system prompt with fixed instructions"""
     fixed_prompt = """あなたはOCR抽出結果を検証し、誤りを修正するアシスタントです。

--- a/agentcore/runtime/src/utils.py
+++ b/agentcore/runtime/src/utils.py
@@ -1,6 +1,5 @@
 """Utility functions for agent runtime."""
 
-import json
 import logging
 from typing import Any
 
@@ -23,14 +22,3 @@ def process_prompt(prompt: str | list[dict[str, Any]]) -> str:
                 text_parts.append(item["text"])
         return "\n".join(text_parts)
     return ""
-
-
-def create_error_response(error_message: str) -> dict:
-    """Create error response"""
-    return {
-        "event": {
-            "internalServerException": {
-                "message": f"An error occurred: {error_message}"
-            }
-        }
-    }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Removes leftover code in `agentcore/runtime/` from before the agent was migrated to the AgentCore Gateway. The current implementation obtains its tools through the Gateway (`src/tools.py`, SigV4-signed `streamablehttp_client` to `AGENTCORE_GATEWAY_ENDPOINT`), so the older "run a local MCP server as a child process" mechanism is no longer used.

Removed:
- `mcp.json` — configured a local `mcp-server-time` MCP server started via `uvx`. It is never referenced: the Dockerfile only copies `app.py` and `src/`, so it is not even included in the container image, and no code or CDK reads it.
- `get_uv_environment()` (`src/config.py`) — set `UV_TOOL_DIR` / `npm_config_cache` / etc. so the runtime could launch local MCP servers with uvx/npx. Unused with the Gateway approach; no callers.
- `create_error_response()` (`src/utils.py`) — unused helper (no callers); removing it also made `import json` in that module unused, so that import was dropped too.

`get_aws_credentials()` is kept — it is still used by `extract_model_info()`.

Verified: `py_compile` passes, `pyflakes` is clean, and there are no remaining references to any removed symbol.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.