### PR TITLE
docs: remove obsolete note about switching OCR engines

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -120,9 +120,6 @@ const envOverrides: Record<string, Partial<AppParameters>> = {
 - `deepseek`: DeepSeek OCR。自前のコンテナで動作し、ゼロスケーリングに対応します。
 - `yomitoku-mp`: Yomitoku Pro（AWS Marketplace 版）。高精度な日本語 OCR です。
 
-> [!Note]
-> OCR エンジンを切り替える際、切り替え前後でエンドポイントの構成が変わる場合（例: `paddle` から `yomitoku-mp` へ変更する場合）は、そのままでは更新できません。一度 `enableOcr: false` でデプロイしてから、`enableOcr: true` に戻して再デプロイしてください。
-
 #### Yomitoku Pro（AWS Marketplace 版）
 
 [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-64qkuwrqi4lhi) でサブスクライブした後、`lib/parameters.ts` に以下を設定します。


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Removed the note in the deployment guide that instructed users to redeploy with `enableOcr: false` and then `true` when switching OCR engines. That in-place update limitation has since been fixed, so the workaround is no longer needed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.