### PR TITLE
docs: fix layer description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ AutoExtract は OCR + Bedrock を活用した帳票読み取りの AI-OCR ソリ
 
 ![architecture](docs/imgs/architecture.drawio.png)
 
-React（CloudFront + S3）、FastAPI（Lambda）、AWS CDK による 3 層構成です。OCR は SageMaker、情報抽出は Bedrock、エージェント検証は Bedrock AgentCore を利用し、権限管理を Aurora DSQL、帳票データを DynamoDB で管理します。詳細は [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) を参照してください。
+フロントエンドは React（CloudFront + S3）、バックエンドは FastAPI（Lambda）で構成し、これらを AWS CDK でデプロイします。OCR は SageMaker、情報抽出は Bedrock、エージェント検証は Bedrock AgentCore を利用し、権限管理を Aurora DSQL、帳票データを DynamoDB で管理します。詳細は [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) を参照してください。
 
 ## クイックスタート
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Fixed the architecture one-liner in README.md. It previously called "React, FastAPI, and AWS CDK" a three-layer structure, but CDK is the IaC tool used to deploy the app, not a runtime layer. Reworded it to describe the frontend (React) and backend (FastAPI), with CDK as what deploys them.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.