### PR TITLE
fix: prevent React crash when extracted values contain nested objects

### DIFF
--- a/web/src/components/shared/ErrorBoundary.tsx
+++ b/web/src/components/shared/ErrorBoundary.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  // 例外時に表示する内容。未指定なら既定のメッセージを出す。
+  fallback?: React.ReactNode;
+  // ここに渡した値のいずれかが変わると、エラー状態を解除して再描画を試みる。
+  // 例: 表示対象データを渡すと、データが更新されたときに自動復帰する。
+  resetKeys?: unknown[];
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+// 子の描画中に投げられた例外を捕捉し、画面全体のクラッシュを防ぐ。
+// 捕捉範囲を限定して使うことで、エラー箇所だけをフォールバック表示にし、
+// 周囲の UI は生存させる。イベントハンドラ内の例外は React の仕様上捕捉しない。
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    // 握りつぶすと将来の不具合が検知不能になるため、必ずログに残す。
+    console.error('ErrorBoundary caught an error:', error, info.componentStack);
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps) {
+    // エラー中に resetKeys が変化したら（データ更新・再抽出など）エラー状態を解除する。
+    // これがないと、原因データが直っても fallback に貼り付いたままになる。
+    if (!this.state.hasError) return;
+    const prev = prevProps.resetKeys ?? [];
+    const next = this.props.resetKeys ?? [];
+    if (prev.length !== next.length || next.some((k, i) => !Object.is(k, prev[i]))) {
+      this.setState({ hasError: false });
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback ?? (
+          <div className="p-4 text-sm text-neutral-600 bg-neutral-50 border border-neutral-200 rounded">
+            表示中にエラーが発生しました。
+          </div>
+        )
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/web/src/pages/ocr-result/ExtractedInfoDisplay.tsx
+++ b/web/src/pages/ocr-result/ExtractedInfoDisplay.tsx
@@ -35,6 +35,42 @@ const numericInputProps = (isNumber: boolean, onValue: (v: string) => void) =>
         onChange: (e: React.ChangeEvent<HTMLInputElement>) => onValue(e.target.value),
       };
 
+// 抽出結果やエージェント提案の値は、スキーマ上は string 想定でも実データが object/array に
+// なりうる（LLM 出力・型ズレ・ネストした項目）。React は object を子要素として描画できず
+// error #31 でクラッシュするため、値を描画する箇所は必ずこの関数を通す。
+// どんな入力でも string か JSX 要素しか返さないことを保証し、object を素で返さない。
+const MAX_NEST_DEPTH = 8;
+
+const renderNestedValue = (value: any, depth: number = 0): React.ReactNode => {
+  if (value === null || value === undefined) return '';
+  const t = typeof value;
+  if (t === 'string' || t === 'number' || t === 'boolean') return String(value);
+  // 深すぎる／string・number・boolean・object 以外（bigint 等）は文字列へ吸収
+  if (depth >= MAX_NEST_DEPTH || (t !== 'object')) {
+    try { return JSON.stringify(value); } catch { return String(value); }
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '';
+    return (
+      <ul className="list-disc pl-4 space-y-0.5">
+        {value.map((v, i) => <li key={i}>{renderNestedValue(v, depth + 1)}</li>)}
+      </ul>
+    );
+  }
+  const entries = Object.entries(value);
+  if (entries.length === 0) return '';
+  return (
+    <div className="space-y-0.5">
+      {entries.map(([k, v]) => (
+        <div key={k} className="flex gap-1">
+          <span className="text-neutral-500 whitespace-nowrap">{k}:</span>
+          <span className="min-w-0 break-words">{renderNestedValue(v, depth + 1)}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
 interface ExtractedInfoDisplayProps {
   extractedInfo: Record<string, any>;
   fields: Field[];
@@ -149,10 +185,10 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
   const renderSuggestion = (suggestion: Suggestion) => (
     <div className="mt-2 p-3 bg-warning-light border border-warning-border rounded">
       <div className="text-sm mb-2">
-        <div className="mb-1">{suggestion.reason}</div>
+        <div className="mb-1">{renderNestedValue(suggestion.reason)}</div>
         <div className="text-xs text-neutral-600">
-          「{suggestion.original_value}」→「{suggestion.suggested_value}」
-          {suggestion.tool_used && <span className="ml-2">({suggestion.tool_used})</span>}
+          「{renderNestedValue(suggestion.original_value)}」→「{renderNestedValue(suggestion.suggested_value)}」
+          {suggestion.tool_used && <span className="ml-2">({renderNestedValue(suggestion.tool_used)})</span>}
         </div>
       </div>
       <div className="flex gap-2">
@@ -238,7 +274,7 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
                 {editMode ? (
                   <input
                     type="text"
-                    value={mapValue[subField.name] || ''}
+                    value={typeof mapValue[subField.name] === 'object' ? '' : (mapValue[subField.name] || '')}
                     {...numericInputProps(subField.type === 'number', (v) => setValueAtPath(fieldPath, v))}
                     onFocus={() => onHighlightField(fieldPath, true)}
                     className="w-full p-2 border border-neutral-300 rounded"
@@ -248,7 +284,7 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
                     className="p-2 bg-neutral-50 border border-neutral-200 rounded cursor-pointer hover:bg-neutral-100 min-h-[2.5rem]"
                     onClick={() => onHighlightField(fieldPath, true)}
                   >
-                    {mapValue[subField.name] || ''}
+                    {renderNestedValue(mapValue[subField.name])}
                   </div>
                 )}
                 {suggestion && renderSuggestion(suggestion)}
@@ -275,7 +311,7 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
               {editMode ? (
                 <input
                   type="text"
-                  value={item || ''}
+                  value={typeof item === 'object' ? '' : (item || '')}
                   {...numericInputProps(field.items?.type === 'number', (v) => {
                     const updated = [...listData];
                     updated[i] = v;
@@ -284,7 +320,7 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
                   className="w-full p-1 border border-neutral-300 rounded text-sm"
                 />
               ) : (
-                <span className="text-sm">{item || ''}</span>
+                <span className="text-sm">{renderNestedValue(item)}</span>
               )}
             </li>
           ))}
@@ -339,15 +375,31 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
                           const cellSuggestion = getSuggestionForField(cellPath);
                           const isEditing = editingCell === cellPath;
                           const isLastCol = colIdx === itemFields.length - 1;
+                          // map/list 型のセルは値がオブジェクト/配列になる。編集経路に入れず、
+                          // 読み取りのネスト展開表示にする（object を素で描画すると error #31 で落ちる）。
+                          const isComplexCell = itemField.type === 'map' || itemField.type === 'list';
 
                           return (
-                            <td key={itemField.name} className="px-3 py-1.5 relative">
-                              {editMode && isEditing ? (
+                            <td key={itemField.name} className="px-3 py-1.5 relative align-top">
+                              {isComplexCell ? (
+                                <div
+                                  className={`text-sm text-neutral-900 px-2 py-1 rounded max-w-xs break-words cursor-pointer min-h-[1.5rem] ${cellSuggestion ? 'text-warning-text font-medium hover:bg-warning-light/50' : 'hover:bg-info-light'}`}
+                                  onClick={() => {
+                                    onHighlightCell(field.name, itemIndex, itemField.name);
+                                    if (rowSuggestions.length > 0) {
+                                      setExpandedSuggestionRow(isExpanded ? null : rowKey);
+                                    }
+                                  }}
+                                >
+                                  {renderNestedValue(item[itemField.name])}
+                                  {cellSuggestion && <span className="ml-1">⚠</span>}
+                                </div>
+                              ) : editMode && isEditing ? (
                                 <input
                                   ref={editInputRef}
                                   type="text"
                                   inputMode={itemField.type === 'number' ? 'numeric' : undefined}
-                                  value={item[itemField.name] || ''}
+                                  value={typeof item[itemField.name] === 'object' ? '' : (item[itemField.name] || '')}
                                   onChange={(e) => {
                                     if (itemField.type !== 'number') {
                                       updateListItemProperty(field.name, itemIndex, itemField.name, e.target.value);
@@ -390,7 +442,7 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
                                     }
                                   }}
                                 >
-                                  {item[itemField.name] || ''}
+                                  {renderNestedValue(item[itemField.name])}
                                   {cellSuggestion && <span className="ml-1">⚠</span>}
                                 </div>
                               )}
@@ -420,10 +472,10 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
                               {rowSuggestions.map((suggestion, i) => (
                                 <div key={i} className="p-3 bg-warning-light border border-warning-border rounded">
                                   <div className="text-sm mb-2">
-                                    <div className="mb-1">{suggestion.reason}</div>
+                                    <div className="mb-1">{renderNestedValue(suggestion.reason)}</div>
                                     <div className="text-xs text-neutral-600">
-                                      「{suggestion.original_value}」→「{suggestion.suggested_value}」
-                                      {suggestion.tool_used && <span className="ml-2">({suggestion.tool_used})</span>}
+                                      「{renderNestedValue(suggestion.original_value)}」→「{renderNestedValue(suggestion.suggested_value)}」
+                                      {suggestion.tool_used && <span className="ml-2">({renderNestedValue(suggestion.tool_used)})</span>}
                                     </div>
                                   </div>
                                   <div className="flex gap-2">
@@ -462,7 +514,7 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
               {editMode ? (
                 <input
                   type="text"
-                  value={item || ''}
+                  value={typeof item === 'object' ? '' : (item || '')}
                   {...numericInputProps(field.items?.type === 'number', (v) => {
                     const updated = [...listData];
                     updated[i] = v;
@@ -471,7 +523,7 @@ const ExtractedInfoDisplay: React.FC<ExtractedInfoDisplayProps> = ({
                   className="w-full p-1 border border-neutral-300 rounded"
                 />
               ) : (
-                <div className="p-1">{item || ''}</div>
+                <div className="p-1">{renderNestedValue(item)}</div>
               )}
             </li>
           ))}

--- a/web/src/pages/ocr-result/OCRResult.tsx
+++ b/web/src/pages/ocr-result/OCRResult.tsx
@@ -15,6 +15,7 @@ import ImagePreview from "./ImagePreview";
 import OcrResultEditor from "./OcrResultEditor";
 import ExtractionStatusDisplay from "./ExtractionStatusDisplay";
 import ExtractedInfoDisplay from "./ExtractedInfoDisplay";
+import ErrorBoundary from "../../components/shared/ErrorBoundary";
 import ReExtractModal from "./ReExtractModal";
 import AgentModal from "./AgentModal";
 import StatusProgressBar from "../../components/ocr-result/StatusProgressBar";
@@ -1185,18 +1186,20 @@ function OcrResult() {
                       <span className="text-sm text-green-700">問題は検出されませんでした</span>
                     </div>
                   )}
-                  <ExtractedInfoDisplay
-                    extractedInfo={extractedInfo}
-                    fields={appFields}
-                    editMode={editMode}
-                    onHighlightField={highlightField}
-                    onHighlightCell={highlightTableCell}
-                    onUpdateExtractedInfo={updateExtractedInfo}
-                    agentSuggestions={agentSuggestions}
-                    onAcceptSuggestion={handleAcceptSuggestion}
-                    onRejectSuggestion={handleRejectSuggestion}
-                    onEnterEditMode={() => { if (agentStatus === 'running') return; suggestionsSnapshotRef.current = [...agentSuggestions]; extractedInfoSnapshotRef.current = { ...extractedInfo }; setEditMode(true); }}
-                  />
+                  <ErrorBoundary resetKeys={[extractedInfo]} fallback={<div className="p-4 text-sm text-neutral-600 bg-neutral-50 border border-neutral-200 rounded">抽出結果の表示中にエラーが発生しました。データ構造が想定外の可能性があります。</div>}>
+                    <ExtractedInfoDisplay
+                      extractedInfo={extractedInfo}
+                      fields={appFields}
+                      editMode={editMode}
+                      onHighlightField={highlightField}
+                      onHighlightCell={highlightTableCell}
+                      onUpdateExtractedInfo={updateExtractedInfo}
+                      agentSuggestions={agentSuggestions}
+                      onAcceptSuggestion={handleAcceptSuggestion}
+                      onRejectSuggestion={handleRejectSuggestion}
+                      onEnterEditMode={() => { if (agentStatus === 'running') return; suggestionsSnapshotRef.current = [...agentSuggestions]; extractedInfoSnapshotRef.current = { ...extractedInfo }; setEditMode(true); }}
+                    />
+                  </ErrorBoundary>
                 </>
               )}
             </div>


### PR DESCRIPTION
*Issue #, if available:* #48 (same class of bug)

*Description of changes:*

The OCR result screen (`/ocr-result/:id`) crashed with a full-page React error #31 ("Objects are not valid as a React child") when a usecase's schema nests objects deeply. Concretely, a `list` field whose rows are `map`s, where one of a row's columns is itself a `map`, passed a raw object into a table cell.

Issue #48 previously fixed the `map → map` display recursively, but the list-table cell renderer still dumped `item[itemField.name]` without checking its type, so this `list → map → map` case slipped through.

This fixes the display side without restricting the schema's expressiveness:

- **`renderNestedValue` (new)** in `ExtractedInfoDisplay.tsx`: a recursive renderer that only ever returns a string or JSX — never a raw object. Primitives → `String()`, arrays → `ul/li`, objects → `key: value` rows, with a depth cap and a `JSON.stringify`/`String` fallback for anything unexpected (bigint, cycles, etc.).
- **Routed every value-render path through it**: the list-table cell (with a type branch so `map`/`list` columns render as read-only expanded values and never enter the edit/`setEditingCell` path), map subfields, nested-list elements, top-level list elements, and the agent suggestion fields (`reason` / `original_value` / `suggested_value` / `tool_used`, which the backend passes through from the LLM without stringifying). Edit inputs fall back to empty string when given an object.
- **`ErrorBoundary` (new, `components/shared/`)**: wraps the extraction display in `OCRResult.tsx` so any unforeseen render error degrades to a local fallback instead of crashing the whole page. It logs via `componentDidCatch` and supports `resetKeys` (passed `extractedInfo`) so it recovers automatically when the data updates.

Verified: `npm run build` (tsc) passes; against a schema that reproduces the deep nesting, the fix renders the nested objects as `key: value` inside the cell with no console error (previously 4× error #31). Two independent code reviews confirmed no crash paths remain and no infinite-loop risk in the ErrorBoundary reset.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.