### PR TITLE
fix: consistent numeric handling for OCR points and DynamoDB Decimal conversion

### DIFF
--- a/lambda/api/app/domains/extraction_engine.py
+++ b/lambda/api/app/domains/extraction_engine.py
@@ -6,7 +6,6 @@ from domains.prompts import (
     create_single_with_ocr_prompt, create_single_without_ocr_prompt,
     create_multi_with_ocr_prompt, create_multi_without_ocr_prompt
 )
-from utils.helpers import float_to_decimal
 from domains.template import generate_unified_template
 import logging
 import json
@@ -58,10 +57,10 @@ def parse_extraction_response(ai_response, field_names):
 
 
 def finalize_extraction_result(extracted_info, mapping=None):
-    """抽出結果を Decimal 変換して最終形式にする"""
-    result = {"extracted_info": float_to_decimal(extracted_info)}
+    """抽出結果を最終形式の dict にまとめる"""
+    result = {"extracted_info": extracted_info}
     if mapping is not None:
-        result["mapping"] = float_to_decimal(mapping)
+        result["mapping"] = mapping
     return result
 
 

--- a/lambda/api/app/domains/ocr_engine.py
+++ b/lambda/api/app/domains/ocr_engine.py
@@ -8,6 +8,32 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def _normalize_points(points):
+    """OCR 座標 (points) をピクセル整数に正規化する。
+
+    `[[x, y], ...]` の各座標を int に丸める。数値でない要素や list-of-list でない形は
+    そのまま返す。
+
+    Args:
+        points: 座標リスト。
+
+    Returns:
+        各座標を int に丸めたリスト。正規化できない形はそのまま返す。
+    """
+    if not isinstance(points, list):
+        return points
+    normalized = []
+    for point in points:
+        if isinstance(point, list):
+            normalized.append([
+                int(round(v)) if isinstance(v, (int, float)) and not isinstance(v, bool) else v
+                for v in point
+            ])
+        else:
+            normalized.append(point)
+    return normalized
+
+
 def parse_ocr_response(response_body: dict) -> dict:
     """SageMaker OCR レスポンスを整形・軽量化する（純粋関数）
 
@@ -29,7 +55,7 @@ def parse_ocr_response(response_body: dict) -> dict:
             simplified_word = {
                 "id": word["id"],
                 "content": word["content"],
-                "points": word["points"],
+                "points": _normalize_points(word["points"]),
             }
             if "direction" in word:
                 simplified_word["direction"] = word["direction"]
@@ -64,7 +90,7 @@ def parse_yomitoku_mp_response(response_body: dict) -> dict:
             all_words.append({
                 "id": word_id,
                 "content": word["content"],
-                "points": word["points"],
+                "points": _normalize_points(word["points"]),
                 "direction": word.get("direction", "horizontal"),
             })
             word_id += 1

--- a/lambda/api/app/repositories/image_repository.py
+++ b/lambda/api/app/repositories/image_repository.py
@@ -9,6 +9,7 @@ from domains.image_status import (
     ImageStatus, PageProcessingMode,
     validate_image_status, validate_agent_status, validate_page_processing_mode,
 )
+from utils.helpers import float_to_decimal
 
 logger = logging.getLogger(__name__)
 
@@ -257,7 +258,7 @@ def update_ocr_result(image_id: str, ocr_result: dict) -> None:
             Key={"id": image_id},
             UpdateExpression="SET ocr_result = :ocr_result",
             ExpressionAttributeValues={
-                ":ocr_result": ocr_result
+                ":ocr_result": float_to_decimal(ocr_result)
             }
         )
         logger.info(f"OCR結果を更新しました: {image_id}")
@@ -267,7 +268,7 @@ def update_ocr_result(image_id: str, ocr_result: dict) -> None:
         raise
 
 
-def update_extracted_info(image_id, extracted_info, extraction_mapping, extracted_fields=None):
+def update_extracted_info(image_id: str, extracted_info: dict, extraction_mapping: dict, extracted_fields: list = None) -> None:
     """
     抽出情報を更新する（Map型で保存）
 
@@ -282,12 +283,12 @@ def update_extracted_info(image_id, extracted_info, extraction_mapping, extracte
 
     update_expression = "SET extracted_info = :extracted_info, extraction_mapping = :extraction_mapping"
     expression_attribute_values = {
-        ":extracted_info": extracted_info,
-        ":extraction_mapping": extraction_mapping,
+        ":extracted_info": float_to_decimal(extracted_info),
+        ":extraction_mapping": float_to_decimal(extraction_mapping),
     }
     if extracted_fields is not None:
         update_expression += ", extracted_fields = :extracted_fields"
-        expression_attribute_values[":extracted_fields"] = extracted_fields
+        expression_attribute_values[":extracted_fields"] = float_to_decimal(extracted_fields)
 
     try:
         table.update_item(

--- a/lambda/api/app/repositories/job_repository.py
+++ b/lambda/api/app/repositories/job_repository.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import uuid
 from config import settings
 from exceptions import NotFoundError, BadRequestError
+from utils.helpers import float_to_decimal
 
 logger = logging.getLogger(__name__)
 
@@ -200,7 +201,7 @@ def update_agent_job(job_id: str, status: str, suggestions: list = None, error: 
 
             if suggestions is not None:
                 update_expr += ", suggestions = :suggestions"
-                expr_attr_values[":suggestions"] = suggestions
+                expr_attr_values[":suggestions"] = float_to_decimal(suggestions)
 
         if error:
             update_expr += ", #error = :error"
@@ -286,7 +287,7 @@ def update_schema_generation_job(job_id: str, status: str, result: dict = None, 
             if result is not None:
                 update_expr += ", #result = :result"
                 expr_attr_names["#result"] = "result"
-                expr_attr_values[":result"] = result
+                expr_attr_values[":result"] = float_to_decimal(result)
 
         if error:
             update_expr += ", #error = :error"

--- a/lambda/api/app/services/agent_service.py
+++ b/lambda/api/app/services/agent_service.py
@@ -14,6 +14,7 @@ from repositories.tool_repository import list_tools, get_usecase_allowed_tool_na
 from repositories.usecase_repository import get_usecase_by_app_name
 from clients import AgentClient, s3_client, invoke_worker_async
 from config import settings
+from utils.helpers import decimal_to_float
 logger = logging.getLogger(__name__)
 
 
@@ -212,7 +213,7 @@ class AgentService:
             System prompt string (data only — instructions are in runtime config)
         """
         return f"""## 検証対象の抽出結果
-{json.dumps(extracted_info, ensure_ascii=False, indent=2)}
+{json.dumps(decimal_to_float(extracted_info), ensure_ascii=False, indent=2)}
 """
     
 

--- a/lambda/api/app/services/ocr_service.py
+++ b/lambda/api/app/services/ocr_service.py
@@ -18,7 +18,7 @@ from clients import s3_client, sagemaker_runtime_client, sfn_client
 from domains.ocr_engine import parse_ocr_response, parse_yomitoku_mp_response
 from domains.image_status import ImageStatus, AgentStatus, PageProcessingMode
 from services.pdf_conversion_service import sync_parent_status
-from utils.helpers import float_to_decimal, compress_image_for_payload
+from utils.helpers import compress_image_for_payload
 
 logger = logging.getLogger(__name__)
 
@@ -257,11 +257,11 @@ class OcrService:
                 updated_page["words"] = page_words
                 updated_pages.append(updated_page)
 
-            combined_result = float_to_decimal({
+            combined_result = {
                 "words": all_words,
                 "pages": updated_pages,
                 "total_pages": len(ocr_results)
-            })
+            }
 
             db_update_ocr_result(image_id, combined_result)
             sync_parent_status(image_id)

--- a/lambda/api/app/tests/domains/test_finalize_extraction_result.py
+++ b/lambda/api/app/tests/domains/test_finalize_extraction_result.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from domains.extraction_engine import finalize_extraction_result
+
+
+class TestFinalizeExtractionResult:
+    def test_floats_are_returned_unchanged(self):
+        # Decimal 変換は repository 層が担うため、ここでは float のまま返す
+        extracted_info = {"total": 1234.56}
+        result = finalize_extraction_result(extracted_info)
+        assert result == {"extracted_info": {"total": 1234.56}}
+        assert isinstance(result["extracted_info"]["total"], float)
+
+    def test_mapping_included_when_present(self):
+        result = finalize_extraction_result({"a": 1}, mapping={"a": [0]})
+        assert result == {"extracted_info": {"a": 1}, "mapping": {"a": [0]}}
+
+    def test_mapping_omitted_when_none(self):
+        result = finalize_extraction_result({"a": 1})
+        assert "mapping" not in result

--- a/lambda/api/app/tests/domains/test_ocr_engine.py
+++ b/lambda/api/app/tests/domains/test_ocr_engine.py
@@ -1,0 +1,81 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from domains.ocr_engine import (
+    _normalize_points,
+    parse_ocr_response,
+    parse_yomitoku_mp_response,
+)
+
+
+class TestNormalizePoints:
+    def test_floats_are_rounded_to_int(self):
+        points = [[1.4, 2.6], [3.5, 4.0]]
+        assert _normalize_points(points) == [[1, 3], [4, 4]]
+        assert all(isinstance(v, int) for p in _normalize_points(points) for v in p)
+
+    def test_ints_are_unchanged(self):
+        points = [[1, 2], [3, 4]]
+        assert _normalize_points(points) == [[1, 2], [3, 4]]
+
+    def test_four_point_structure_preserved(self):
+        points = [[0.1, 0.9], [10.2, 0.9], [10.2, 5.1], [0.1, 5.1]]
+        result = _normalize_points(points)
+        assert len(result) == 4
+        assert result == [[0, 1], [10, 1], [10, 5], [0, 5]]
+
+    def test_none_passthrough(self):
+        assert _normalize_points(None) is None
+
+    def test_non_list_passthrough(self):
+        assert _normalize_points("not-a-list") == "not-a-list"
+
+    def test_non_list_of_list_passthrough(self):
+        # 座標が list でない要素は素通し
+        assert _normalize_points([1, 2, 3]) == [1, 2, 3]
+
+    def test_non_numeric_coordinate_passthrough(self):
+        # 数値でない座標値は変換せずそのまま
+        assert _normalize_points([["a", "b"]]) == [["a", "b"]]
+
+    def test_bool_not_treated_as_number(self):
+        # bool は数値に丸めない
+        assert _normalize_points([[True, False]]) == [[True, False]]
+
+
+class TestParseOcrResponse:
+    def test_points_normalized_to_int_and_rec_score_dropped(self):
+        response = {
+            "words": [
+                {"id": 0, "content": "abc", "rec_score": 0.98,
+                 "points": [[1.4, 2.6], [3.5, 4.0]]},
+            ]
+        }
+        result = parse_ocr_response(response)
+        word = result["words"][0]
+        assert word["points"] == [[1, 3], [4, 4]]
+        assert "rec_score" not in word
+        assert result["word_count"] == 1
+        assert result["text"] == "abc"
+
+    def test_error_response_passthrough(self):
+        response = {"error": "boom"}
+        assert parse_ocr_response(response) == {"error": "boom"}
+
+
+class TestParseYomitokuResponse:
+    def test_points_normalized_to_int(self):
+        response = {
+            "result": [
+                {"words": [
+                    {"content": "xyz", "points": [[5.7, 6.2]], "direction": "horizontal"},
+                ]}
+            ]
+        }
+        result = parse_yomitoku_mp_response(response)
+        word = result["words"][0]
+        assert word["points"] == [[6, 6]]
+        assert word["content"] == "xyz"
+        assert result["word_count"] == 1

--- a/lambda/api/app/tests/services/test_agent_system_prompt.py
+++ b/lambda/api/app/tests/services/test_agent_system_prompt.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import json
+from decimal import Decimal
+
+from services.agent_service import AgentService
+
+
+class TestCreateSystemPrompt:
+    def test_decimal_values_are_serializable(self):
+        # DynamoDB から読んだ extracted_info は数値が Decimal になっている
+        extracted_info = {"total": Decimal("1234.56"), "name": "sample"}
+        prompt = AgentService._create_system_prompt(AgentService.__new__(AgentService), extracted_info)
+        # json.dumps が例外を投げず、数値が float として埋め込まれる
+        assert "1234.56" in prompt
+        assert "sample" in prompt
+
+    def test_nested_decimal_values(self):
+        extracted_info = {"items": [{"price": Decimal("9.99")}]}
+        prompt = AgentService._create_system_prompt(AgentService.__new__(AgentService), extracted_info)
+        assert "9.99" in prompt
+        # 埋め込まれた JSON 部分が再パース可能であること
+        json_part = prompt.split("\n", 1)[1].strip()
+        assert json.loads(json_part) == {"items": [{"price": 9.99}]}

--- a/lambda/api/app/tests/utils/test_float_to_decimal.py
+++ b/lambda/api/app/tests/utils/test_float_to_decimal.py
@@ -1,0 +1,58 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from decimal import Decimal
+
+from utils.helpers import float_to_decimal
+
+
+class TestFloatToDecimal:
+    def test_float_becomes_decimal(self):
+        assert float_to_decimal(1.5) == Decimal("1.5")
+        assert isinstance(float_to_decimal(1.5), Decimal)
+
+    def test_decimal_passthrough_is_idempotent(self):
+        once = float_to_decimal(2.5)
+        twice = float_to_decimal(once)
+        assert once == twice == Decimal("2.5")
+        assert isinstance(twice, Decimal)
+
+    def test_int_passthrough(self):
+        assert float_to_decimal(3) == 3
+        assert isinstance(float_to_decimal(3), int)
+
+    def test_bool_is_not_converted(self):
+        assert float_to_decimal(True) is True
+        assert float_to_decimal(False) is False
+
+    def test_str_and_none_passthrough(self):
+        assert float_to_decimal("abc") == "abc"
+        assert float_to_decimal(None) is None
+
+    def test_nested_dict_and_list(self):
+        payload = {
+            "amount": 100.5,
+            "items": [{"price": 9.99}, {"price": 5}],
+            "label": "invoice",
+        }
+        result = float_to_decimal(payload)
+        assert result["amount"] == Decimal("100.5")
+        assert result["items"][0]["price"] == Decimal("9.99")
+        assert result["items"][1]["price"] == 5
+        assert result["label"] == "invoice"
+
+    def test_extracted_info_like_payload(self):
+        payload = {"total": 1234.56, "customer": "sample"}
+        result = float_to_decimal(payload)
+        assert result["total"] == Decimal("1234.56")
+
+    def test_suggestions_like_payload(self):
+        suggestions = [
+            {"original_value": 10.0, "suggested_value": 12.5, "field": "qty"},
+        ]
+        result = float_to_decimal(suggestions)
+        assert result[0]["original_value"] == Decimal("10.0")
+        assert result[0]["suggested_value"] == Decimal("12.5")
+        assert result[0]["field"] == "qty"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

DynamoDB (boto3 resource) rejects Python `float`. The helper `float_to_decimal` existed but was applied inconsistently at the caller level, which mixed together two independent problems. This PR separates and fixes them.

**Problem A — normalize OCR `points` to integers at the parse layer**

OCR coordinate (`points`) types differed per engine (deepseek emits int, paddle emits float, yomitoku is undefined), and only the combined-page save path wrapped the result in `float_to_decimal`. As a result the same data could succeed in combined mode but fail on the single/individual OCR path. Coordinates are pixel values, so int is the natural type.

- Add `_normalize_points` in `domains/ocr_engine.py` and apply it in `parse_ocr_response` and `parse_yomitoku_mp_response`, so all engines and all OCR ingest routes store integer coordinates. Non-numeric / unexpected shapes pass through unchanged.
- Remove the now-unnecessary `float_to_decimal` wrapper from the combined-save path in `services/ocr_service.py`.

**Problem B — apply Decimal conversion at the repository write layer for genuinely-float values**

Amounts, confidence scores and agent/schema numeric outputs are inherently float and must be Decimal-converted for DynamoDB. Conversion was missing on several write paths (extraction edit-save, OCR edit-save, agent suggestions, schema-generation result), so those writes could fail.

- Convert at the DynamoDB boundary: `update_extracted_info` (all args), `update_ocr_result` in `image_repository.py`; `update_agent_job` (suggestions), `update_schema_generation_job` (result) in `job_repository.py`.
- Remove the redundant caller-level conversion in `finalize_extraction_result`, making the repository layer the single source of truth.

**Related fix — agent prompt serialization**

`agent_service._create_system_prompt` ran `json.dumps` on extracted info read from DynamoDB, which raised `TypeError` on `Decimal` values (agent verification failed for any document with a numeric field). It now converts via `decimal_to_float` first.

**Tests**

Added unit tests for `_normalize_points` (including malformed-input passthrough), the two OCR parsers, `float_to_decimal` (idempotency, bool-safety, nested payloads), `finalize_extraction_result`, and the agent prompt Decimal serialization. Full suite: 94 passed. pyflakes clean on all changed files.

**Out of scope (noted for follow-up)**

- `schema_repository` writes frontend `input_methods: Dict[str, Any]` without conversion (float-free in practice).
- Non-finite floats (NaN/Infinity) from JSON are rejected by DynamoDB even after Decimal conversion (pre-existing, low probability).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.