### PR TITLE
fix: consolidate OCR start and fix list UI issues

### DIFF
--- a/lambda/api/app/domains/schema_fields.py
+++ b/lambda/api/app/domains/schema_fields.py
@@ -1,6 +1,25 @@
 """スキーマフィールドのドメインロジック"""
 
 
+def should_run_agent(schema: dict | None, manual: bool = False) -> bool:
+    """このユースケースで Agent 検証を実行すべきか判定する。
+
+    手動実行は `agent_enabled` のみ要求する。自動実行（抽出後の連動）は
+    `agent_enabled` かつ `agent_auto_run` の両方が必要。
+
+    Args:
+        schema: app スキーマ（None 可）
+        manual: 手動実行なら True
+
+    Returns:
+        検証を実行すべきなら True
+    """
+    enabled = bool(schema and schema.get("agent_enabled", False))
+    if manual:
+        return enabled
+    return enabled and bool(schema and schema.get("agent_auto_run", False))
+
+
 def extract_field_names(fields: list[dict], prefix: str = "") -> list[str]:
     """フィールド定義から階層構造を考慮したフィールド名リストを生成する。
 

--- a/lambda/api/app/routers/apps.py
+++ b/lambda/api/app/routers/apps.py
@@ -131,12 +131,16 @@ async def get_app_schema_generation_status(job_id: str, user=Depends(RequireRole
 @router.post("/apps/{app_name}/jobs", response_model=JobStartResponse)
 async def start_batch_job(
     app_name: str,
+    body: OcrStartRequest = OcrStartRequest(),
     user=Depends(RequirePermission("viewer")),
     service: OcrService = Depends(get_ocr_service),
 ):
-    """バッチ一括パイプライン起動（OCR→抽出→Agent）"""
-    request = OcrStartRequest(app_name=app_name)
-    result = await service.start_step_functions_job(request)
+    """バッチ一括パイプライン起動（OCR→抽出→Agent）。
+
+    body.image_ids 省略時はその app の PENDING 画像全件、指定時はその画像群を対象にする。
+    """
+    body.app_name = app_name  # パスを正とし、body の app_name は上書きする（cross-app 防止）
+    result = await service.start_step_functions_job(body)
     return JobStartResponse(jobId=result["jobId"])
 
 

--- a/lambda/api/app/schemas/ocr.py
+++ b/lambda/api/app/schemas/ocr.py
@@ -36,3 +36,5 @@ class OcrResultResponse(BaseModel):
 class OcrStartRequest(BaseModel):
     """OCR処理開始リクエスト"""
     app_name: Optional[str] = None
+    image_ids: Optional[List[str]] = None
+    skip_ocr: bool = False

--- a/lambda/api/app/services/extraction_service.py
+++ b/lambda/api/app/services/extraction_service.py
@@ -6,14 +6,15 @@ from repositories import (
     get_image, update_extracted_info,
     update_image_status, get_extraction_fields_for_app,
     get_custom_prompt_for_app,
-    get_app_display_name, update_verification_status
+    get_app_display_name, update_verification_status,
+    get_app_schema, update_agent_status
 )
 from config import settings
 from exceptions import NotFoundError
 from utils import decimal_to_float
 from utils.bedrock import parse_converse_response, extract_json_from_response
-from domains.schema_fields import extract_field_names
-from domains.image_status import ImageStatus, PageProcessingMode
+from domains.schema_fields import extract_field_names, should_run_agent
+from domains.image_status import ImageStatus, AgentStatus, PageProcessingMode
 from clients import s3_client
 from clients.bedrock import call_bedrock, call_bedrock_with_retry
 from domains.extraction_engine import (
@@ -127,6 +128,13 @@ class InformationExtractor(ABC):
                 result.get("mapping", {}),
                 extracted_fields=app_extraction_fields.get("fields", [])
             )
+
+            # Agent 検証が自動実行されるユースケースでは、COMPLETED にする前に agent_status を
+            # PROCESSING にする。検証は次の Step Functions ステップ（AgentKick）で走るため、
+            # ここで先に立てておくことで「完了」と「検証中」の間の空白状態を無くす。
+            if should_run_agent(get_app_schema(app_name)):
+                update_agent_status(self.image_id, AgentStatus.PROCESSING)
+
             update_image_status(self.image_id, ImageStatus.COMPLETED)
 
             logger.info(f"情報抽出完了: {self.image_id}")

--- a/lambda/api/app/services/ocr_service.py
+++ b/lambda/api/app/services/ocr_service.py
@@ -2,7 +2,7 @@ import uuid
 import logging
 import json
 import base64
-from typing import Dict, Any
+from typing import Dict, Any, List, Optional
 
 from exceptions import EndpointNotReadyError, NotFoundError, BadRequestError
 from repositories import (
@@ -275,105 +275,113 @@ class OcrService:
     # Step Functions 起動
     # ========================================
 
-    async def start_step_functions_job(self, request) -> Dict[str, Any]:
-        """Step FunctionsでOCRジョブを開始する"""
-        try:
-            # OCR有効時のみエンドポイント状態確認
-            if self.enable_ocr:
-                status = self.get_endpoint_status()
+    def _check_endpoint_ready(self, skip_ocr: bool) -> None:
+        """OCR エンドポイントが処理可能か確認する。未起動なら wakeup を促し例外を投げる。"""
+        if skip_ocr or not self.enable_ocr:
+            return
+        status = self.get_endpoint_status()
+        if not status['ready']:
+            if settings.OCR_ENGINE != "yomitoku-mp":
+                trigger_endpoint_wakeup(settings.SAGEMAKER_ENDPOINT_NAME, settings.SAGEMAKER_INFERENCE_COMPONENT_NAME)
+            raise EndpointNotReadyError('OCR エンドポイントが起動中です。しばらくお待ちください。')
 
-                if not status['ready']:
-                    if settings.OCR_ENGINE != "yomitoku-mp":
-                        trigger_endpoint_wakeup(settings.SAGEMAKER_ENDPOINT_NAME, settings.SAGEMAKER_INFERENCE_COMPONENT_NAME)
-                    raise EndpointNotReadyError('OCR エンドポイントが起動中です。しばらくお待ちください。')
+    async def _start_pipeline(
+        self, image_ids: List[str], skip_ocr: bool, job_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """指定画像群の OCR→抽出パイプラインを 1 つの Step Functions 実行で開始する。
 
-            job_id = str(uuid.uuid4())
-            app_name = request.app_name
+        バッチ起動・単一起動の共通実体。エンドポイント確認 → ステータス更新 → SFn 起動を
+        この順で行う。SFn 起動に失敗したら各画像を元のステータスへ戻す。
+        """
+        job_id = job_id or str(uuid.uuid4())
 
-            # pending画像を取得
-            images = get_images(app_name)
-            pending_images = [img for img in images if img.get('status') == ImageStatus.PENDING]
-
-            logger.info(f"Found {len(pending_images)} pending images for app: {app_name}")
-
-            if not pending_images:
-                logger.warning(f"No pending images found for app: {app_name}")
-                return {"jobId": job_id}
-
-            # Step Functions の StartExecution 入力は 256KB 制限がある。
-            # 1 実行あたりの画像数を上限で切り、超過分は pending のまま残して
-            # 次回実行で処理させる（入力ペイロード超過による起動失敗を防ぐ）。
-            if len(pending_images) > MAX_IMAGES_PER_EXECUTION:
-                logger.warning(
-                    f"Pending images ({len(pending_images)}) exceed per-execution limit "
-                    f"({MAX_IMAGES_PER_EXECUTION}) for app: {app_name}. "
-                    f"Processing first {MAX_IMAGES_PER_EXECUTION}; remainder stays pending for the next run."
-                )
-                pending_images = pending_images[:MAX_IMAGES_PER_EXECUTION]
-
-            # ステータスを更新
-            for img in pending_images:
-                update_image_status(img['id'], ImageStatus.PROCESSING, job_id)
-
-            # Step Functions起動
-            try:
-                execution_response = sfn_client.start_execution(
-                    stateMachineArn=settings.STATE_MACHINE_ARN,
-                    name=f"ocr-job-{job_id}",
-                    input=json.dumps({
-                        'job_id': job_id,
-                        'images': [{'image_id': img['id'], 'skip_ocr': False} for img in pending_images]
-                    })
-                )
-            except Exception as sfn_error:
-                logger.error(f"Step Functions start failed, reverting image statuses: {sfn_error}")
-                for img in pending_images:
-                    update_image_status(img['id'], ImageStatus.PENDING)
-                raise
-
-            logger.info(f"Started Step Functions execution: {execution_response['executionArn']}")
-
+        # 重複除去（順序は保持）
+        unique_ids = list(dict.fromkeys(image_ids))
+        if not unique_ids:
             return {"jobId": job_id}
 
-        except Exception as e:
-            logger.error(f"OCR job start error: {str(e)}")
-            raise
+        # エンドポイント確認はステータスを触る前に行う（未起動なら何も変更せず例外）。
+        self._check_endpoint_ready(skip_ocr)
 
-    async def start_step_functions_for_image(self, image_id: str, skip_ocr: bool = False) -> Dict[str, Any]:
-        """指定画像のStep Functions OCR処理を開始する"""
+        # Step Functions の StartExecution 入力は 256KB 制限があるため上限で切る。
+        if len(unique_ids) > MAX_IMAGES_PER_EXECUTION:
+            logger.warning(
+                f"Image count ({len(unique_ids)}) exceeds per-execution limit "
+                f"({MAX_IMAGES_PER_EXECUTION}). Processing first {MAX_IMAGES_PER_EXECUTION}."
+            )
+            unique_ids = unique_ids[:MAX_IMAGES_PER_EXECUTION]
+
+        # ロールバック用に各画像の現ステータスを控える。
+        prior_statuses = {img_id: self._get_image_status(img_id) for img_id in unique_ids}
+
         try:
-            # OCRをスキップしない場合かつOCR有効時のみエンドポイント状態確認
-            if not skip_ocr and self.enable_ocr:
-                status = self.get_endpoint_status()
+            for img_id in unique_ids:
+                # 再処理の起点。抽出フェーズへの遷移は extract() 冒頭が担う。
+                update_image_status(img_id, ImageStatus.OCR, job_id)
+                # 過去の agent 結果を破棄する意味で idle に戻す。AgentKick が実行時に更新する。
+                update_agent_status(img_id, AgentStatus.IDLE, suggestions_count=0)
 
-                if not status['ready']:
-                    if settings.OCR_ENGINE != "yomitoku-mp":
-                        trigger_endpoint_wakeup(settings.SAGEMAKER_ENDPOINT_NAME, settings.SAGEMAKER_INFERENCE_COMPONENT_NAME)
-                    raise EndpointNotReadyError('OCR エンドポイントが起動中です。しばらくお待ちください。')
-
-            job_id = str(uuid.uuid4())
-
-            # 再処理の起点。抽出フェーズへの遷移は extract() 冒頭が担う。
-            update_image_status(image_id, ImageStatus.OCR, job_id)
-
-            # agent 検証は AgentKick が実行時に PROCESSING へ更新する。ここでは過去結果を
-            # 破棄する意味で idle に戻す（auto_run 無効なら idle のまま＝抽出で完結）。
-            update_agent_status(image_id, AgentStatus.IDLE, suggestions_count=0)
-
-            # Step Functions起動（単一画像）
             execution_response = sfn_client.start_execution(
                 stateMachineArn=settings.STATE_MACHINE_ARN,
-                name=f"ocr-single-{image_id}-{job_id[:8]}",
+                name=f"ocr-job-{job_id}",
                 input=json.dumps({
                     'job_id': job_id,
-                    'images': [{'image_id': image_id, 'skip_ocr': skip_ocr}]
+                    'images': [{'image_id': img_id, 'skip_ocr': skip_ocr} for img_id in unique_ids]
                 })
             )
-
-            logger.info(f"Started Step Functions execution for image {image_id}: {execution_response['executionArn']}")
-
-            return {"status": "processing", "image_id": image_id, "job_id": job_id}
-
-        except Exception as e:
-            logger.error(f"Error starting OCR for image: {str(e)}")
+        except Exception as start_error:
+            logger.error(f"Step Functions start failed, reverting image statuses: {start_error}")
+            for img_id, prior in prior_statuses.items():
+                if prior:
+                    update_image_status(img_id, prior)
             raise
+
+        logger.info(f"Started Step Functions execution: {execution_response['executionArn']}")
+        return {"jobId": job_id}
+
+    @staticmethod
+    def _get_image_status(image_id: str) -> Optional[str]:
+        """ロールバック用に画像の現ステータスを取得する（取得失敗時は None）。"""
+        image = get_image(image_id)
+        return image.get('status') if image else None
+
+    async def start_step_functions_job(self, request) -> Dict[str, Any]:
+        """app 単位で OCR パイプラインを開始する。
+
+        request.image_ids 省略時はその app の PENDING 画像全件、指定時はその画像群
+        （app に属することを検証）を対象にする。
+        """
+        app_name = request.app_name
+        image_ids = getattr(request, "image_ids", None)
+        skip_ocr = getattr(request, "skip_ocr", False)
+
+        app_images = get_images(app_name)
+
+        if image_ids:
+            # 指定 ID が app に属することを検証（属さない ID があれば弾く）。
+            known_ids = {img['id'] for img in app_images}
+            invalid = [i for i in image_ids if i not in known_ids]
+            if invalid:
+                raise BadRequestError(f"指定された画像がアプリ '{app_name}' に存在しません: {invalid}")
+            target_ids = image_ids
+        else:
+            # 省略時は PENDING 全件。individual モードの親コンテナ（子を束ねる表示用・
+            # parent_document_id を持たない親）は OCR 対象でないため除外する。
+            target_ids = [
+                img['id'] for img in app_images
+                if img.get('status') == ImageStatus.PENDING and not self._is_parent_container(img, app_images)
+            ]
+            logger.info(f"Found {len(target_ids)} pending images for app: {app_name}")
+
+        return await self._start_pipeline(target_ids, skip_ocr)
+
+    @staticmethod
+    def _is_parent_container(image: Dict[str, Any], all_images: List[Dict[str, Any]]) -> bool:
+        """individual モードの親コンテナ（自身は子を持ち、親を持たない）か判定する。"""
+        if image.get('parent_document_id'):
+            return False
+        return any(other.get('parent_document_id') == image['id'] for other in all_images)
+
+    async def start_step_functions_for_image(self, image_id: str, skip_ocr: bool = False) -> Dict[str, Any]:
+        """指定画像 1 件の OCR パイプラインを開始する（再処理・再抽出用）。"""
+        return await self._start_pipeline([image_id], skip_ocr)

--- a/lambda/api/app/tests/domains/test_should_run_agent.py
+++ b/lambda/api/app/tests/domains/test_should_run_agent.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from domains.schema_fields import should_run_agent
+
+
+class TestShouldRunAgent:
+    def test_auto_run_requires_enabled_and_auto_run(self):
+        assert should_run_agent({"agent_enabled": True, "agent_auto_run": True}) is True
+        assert should_run_agent({"agent_enabled": True, "agent_auto_run": False}) is False
+        assert should_run_agent({"agent_enabled": False, "agent_auto_run": True}) is False
+
+    def test_manual_requires_only_enabled(self):
+        assert should_run_agent({"agent_enabled": True, "agent_auto_run": False}, manual=True) is True
+        assert should_run_agent({"agent_enabled": False, "agent_auto_run": True}, manual=True) is False
+
+    def test_none_schema_is_false(self):
+        assert should_run_agent(None) is False
+        assert should_run_agent(None, manual=True) is False
+
+    def test_missing_keys_default_false(self):
+        assert should_run_agent({}) is False
+        assert should_run_agent({}, manual=True) is False

--- a/lambda/api/app/tests/services/test_ocr_start.py
+++ b/lambda/api/app/tests/services/test_ocr_start.py
@@ -1,0 +1,181 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import asyncio
+import json
+
+import pytest
+
+import services.ocr_service as ocr_module
+from services.ocr_service import OcrService
+from domains.image_status import ImageStatus, AgentStatus
+from exceptions import BadRequestError, EndpointNotReadyError
+
+
+class _FakeSfn:
+    def __init__(self):
+        self.calls = []
+
+    def start_execution(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"executionArn": "arn:aws:states:::execution/test"}
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    """外部依存を差し替え、呼び出しを記録する。"""
+    state = {
+        "status_updates": [],   # (image_id, status)
+        "agent_updates": [],    # (image_id, status)
+        "images": {},           # image_id -> record (get_image 用)
+        "app_images": [],       # get_images(app_name) の戻り
+    }
+
+    fake_sfn = _FakeSfn()
+    monkeypatch.setattr(ocr_module, "sfn_client", fake_sfn)
+    monkeypatch.setattr(ocr_module.settings, "STATE_MACHINE_ARN", "arn:sm")
+    monkeypatch.setattr(
+        ocr_module, "update_image_status",
+        lambda image_id, status, job_id=None: state["status_updates"].append((image_id, status)),
+    )
+    monkeypatch.setattr(
+        ocr_module, "update_agent_status",
+        lambda image_id, status, suggestions_count=None: state["agent_updates"].append((image_id, status)),
+    )
+    monkeypatch.setattr(ocr_module, "get_image", lambda image_id: state["images"].get(image_id))
+    monkeypatch.setattr(ocr_module, "get_images", lambda app_name: state["app_images"])
+
+    state["sfn"] = fake_sfn
+    return state
+
+
+def _make_service(monkeypatch, enable_ocr=True, endpoint_ready=True):
+    monkeypatch.setattr(ocr_module.settings, "ENABLE_OCR", enable_ocr)
+    svc = OcrService()
+    monkeypatch.setattr(svc, "get_endpoint_status", lambda: {"ready": endpoint_ready})
+    return svc
+
+
+class TestStartPipeline:
+    def test_sets_ocr_status_and_agent_reset_and_starts_one_execution(self, patched, monkeypatch):
+        svc = _make_service(monkeypatch)
+        patched["images"] = {"a": {"status": "pending"}, "b": {"status": "pending"}}
+
+        result = asyncio.run(svc._start_pipeline(["a", "b"], skip_ocr=False))
+
+        assert "jobId" in result
+        # 各画像が OCR に、agent が idle にリセットされる
+        assert ("a", ImageStatus.OCR) in patched["status_updates"]
+        assert ("b", ImageStatus.OCR) in patched["status_updates"]
+        assert ("a", AgentStatus.IDLE) in patched["agent_updates"]
+        # SFn 実行は 1 回、images に全 id が入る
+        assert len(patched["sfn"].calls) == 1
+        payload = json.loads(patched["sfn"].calls[0]["input"])
+        assert [i["image_id"] for i in payload["images"]] == ["a", "b"]
+
+    def test_dedupes_ids(self, patched, monkeypatch):
+        svc = _make_service(monkeypatch)
+        patched["images"] = {"a": {"status": "pending"}}
+        asyncio.run(svc._start_pipeline(["a", "a", "a"], skip_ocr=False))
+        payload = json.loads(patched["sfn"].calls[0]["input"])
+        assert [i["image_id"] for i in payload["images"]] == ["a"]
+
+    def test_empty_list_is_noop(self, patched, monkeypatch):
+        svc = _make_service(monkeypatch)
+        result = asyncio.run(svc._start_pipeline([], skip_ocr=False))
+        assert "jobId" in result
+        assert len(patched["sfn"].calls) == 0
+        assert patched["status_updates"] == []
+
+    def test_endpoint_not_ready_raises_before_status_change(self, patched, monkeypatch):
+        svc = _make_service(monkeypatch, endpoint_ready=False)
+        monkeypatch.setattr(ocr_module, "trigger_endpoint_wakeup", lambda *a, **k: None)
+        monkeypatch.setattr(ocr_module.settings, "OCR_ENGINE", "paddle")
+
+        with pytest.raises(EndpointNotReadyError):
+            asyncio.run(svc._start_pipeline(["a"], skip_ocr=False))
+        # ステータスは一切触られていない
+        assert patched["status_updates"] == []
+        assert len(patched["sfn"].calls) == 0
+
+    def test_rollback_restores_prior_status(self, patched, monkeypatch):
+        svc = _make_service(monkeypatch)
+        # 元 COMPLETED の画像を再処理し、SFn 起動が失敗するケース
+        patched["images"] = {"a": {"status": "completed"}}
+
+        def boom(**kwargs):
+            raise RuntimeError("sfn down")
+        monkeypatch.setattr(patched["sfn"], "start_execution", boom)
+
+        with pytest.raises(RuntimeError):
+            asyncio.run(svc._start_pipeline(["a"], skip_ocr=False))
+
+        # OCR にした後、prior の completed に戻す（pending 固定にしない）
+        assert ("a", ImageStatus.OCR) in patched["status_updates"]
+        assert ("a", "completed") in patched["status_updates"]
+
+
+class TestBatchResolver:
+    def test_omitted_ids_selects_pending_excluding_parent_container(self, patched, monkeypatch):
+        svc = _make_service(monkeypatch)
+        # p1 は個別ページの親コンテナ（子 c1 が p1 を parent に持つ）→ 除外
+        patched["app_images"] = [
+            {"id": "p1", "status": "pending"},
+            {"id": "c1", "status": "pending", "parent_document_id": "p1"},
+            {"id": "s1", "status": "pending"},
+            {"id": "done", "status": "completed"},
+        ]
+        patched["images"] = {img["id"]: img for img in patched["app_images"]}
+
+        class Req:
+            app_name = "app"
+            image_ids = None
+            skip_ocr = False
+
+        asyncio.run(svc.start_step_functions_job(Req()))
+        payload = json.loads(patched["sfn"].calls[0]["input"])
+        started = sorted(i["image_id"] for i in payload["images"])
+        # 親コンテナ p1 と completed は除外、c1 と s1 のみ
+        assert started == ["c1", "s1"]
+
+    def test_provided_ids_rejects_cross_app(self, patched, monkeypatch):
+        svc = _make_service(monkeypatch)
+        patched["app_images"] = [{"id": "a", "status": "pending"}]
+
+        class Req:
+            app_name = "app"
+            image_ids = ["a", "foreign"]
+            skip_ocr = False
+
+        with pytest.raises(BadRequestError):
+            asyncio.run(svc.start_step_functions_job(Req()))
+        assert len(patched["sfn"].calls) == 0
+
+    def test_provided_ids_starts_only_those(self, patched, monkeypatch):
+        svc = _make_service(monkeypatch)
+        patched["app_images"] = [
+            {"id": "a", "status": "pending"},
+            {"id": "b", "status": "pending"},
+        ]
+        patched["images"] = {img["id"]: img for img in patched["app_images"]}
+
+        class Req:
+            app_name = "app"
+            image_ids = ["a"]
+            skip_ocr = False
+
+        asyncio.run(svc.start_step_functions_job(Req()))
+        payload = json.loads(patched["sfn"].calls[0]["input"])
+        assert [i["image_id"] for i in payload["images"]] == ["a"]
+
+
+class TestSingleWrapper:
+    def test_delegates_to_pipeline(self, patched, monkeypatch):
+        svc = _make_service(monkeypatch)
+        patched["images"] = {"x": {"status": "completed"}}
+        result = asyncio.run(svc.start_step_functions_for_image("x", skip_ocr=True))
+        assert "jobId" in result
+        payload = json.loads(patched["sfn"].calls[0]["input"])
+        assert payload["images"] == [{"image_id": "x", "skip_ocr": True}]

--- a/lambda/api/app/workers/agent_kick.py
+++ b/lambda/api/app/workers/agent_kick.py
@@ -16,6 +16,7 @@ from repositories.schema_repository import get_app_schema
 from services.agent_service import AgentService
 from services.pdf_conversion_service import sync_parent_agent_status
 from domains.image_status import AgentStatus
+from domains.schema_fields import should_run_agent
 from repositories.job_repository import JobStatus
 
 logger = logging.getLogger(__name__)
@@ -69,9 +70,7 @@ def agent_kick_handler(event, context):
     # 自動実行（Step Functions 経由）は agent_enabled かつ agent_auto_run のときのみ。
     is_manual = event.get("manual", False)
     schema = get_app_schema(app_name)
-    enabled = bool(schema and schema.get("agent_enabled", False))
-    allowed = enabled if is_manual else (enabled and bool(schema.get("agent_auto_run", False)))
-    if not allowed:
+    if not should_run_agent(schema, manual=is_manual):
         reason = "agent_enabled=false" if is_manual else "agent_auto_run=false"
         logger.info(f"Agent skipped for app {app_name} (manual={is_manual}): {reason}")
         # 検証対象外のユースケースは「検証していない」状態＝idle にする。

--- a/web/src/components/ui/Pagination.tsx
+++ b/web/src/components/ui/Pagination.tsx
@@ -110,7 +110,9 @@ function NavButton({ children, ...props }: React.ButtonHTMLAttributes<HTMLButton
       {...props}
       className={`p-1.5 rounded border border-default transition-colors
         ${props.disabled ? 'opacity-40 cursor-not-allowed' : 'hover:bg-neutral-50'}`}
-    />
+    >
+      {children}
+    </button>
   );
 }
 

--- a/web/src/pages/upload/Upload.tsx
+++ b/web/src/pages/upload/Upload.tsx
@@ -105,11 +105,11 @@ function Upload() {
     }
   };
 
-  // 選択された pending Image だけを順次開始する。
-  // 途中でエンドポイント起動待ちになった場合は、未開始分だけを再開する。
+  // 選択された pending Image を app 単位のバッチ API で一括開始する。
+  // Step Functions の Map(maxConcurrency) が同時実行を絞るため、対象 ID をまとめて渡す。
+  // エンドポイント起動待ちのときは、同じバッチを丸ごと再送する。
   const startOcrTargets = async (
     targetIds: string[],
-    totalCount = targetIds.length,
     requestGeneration = ocrRequestGenerationRef.current
   ) => {
     if (
@@ -119,64 +119,51 @@ function Upload() {
 
     try {
       setIsProcessing(true);
-      for (let index = 0; index < targetIds.length; index += 1) {
-        if (requestGeneration !== ocrRequestGenerationRef.current) return;
-
-        try {
-          await api.post(`/images/${targetIds[index]}/process`, { skip_ocr: false });
-        } catch (error: any) {
-          if (error.response?.status === 503 && error.apiErrorCode === 'endpoint_not_ready') {
-            const remainingTargetIds = targetIds.slice(index);
-            setIsEndpointWarming(true);
-
-            if (warmingPollRef.current) clearInterval(warmingPollRef.current);
-            warmingPollRef.current = setInterval(async () => {
-              if (requestGeneration !== ocrRequestGenerationRef.current) {
-                if (warmingPollRef.current) {
-                  clearInterval(warmingPollRef.current);
-                  warmingPollRef.current = null;
-                }
-                return;
-              }
-
-              try {
-                const statusResponse = await api.get('/system/ocr-endpoint-status');
-
-                if (statusResponse.data.ready) {
-                  if (warmingPollRef.current) {
-                    clearInterval(warmingPollRef.current);
-                    warmingPollRef.current = null;
-                  }
-                  setIsEndpointWarming(false);
-                  void startOcrTargets(
-                    remainingTargetIds,
-                    totalCount,
-                    requestGeneration
-                  );
-                }
-              } catch (pollError) {
-                console.error('ポーリングエラー:', pollError);
-              }
-            }, 10000);
-
-            return;
-          }
-
-          throw error;
-        }
-      }
+      await api.post(`/apps/${appName}/jobs`, { image_ids: targetIds, skip_ocr: false });
 
       if (requestGeneration !== ocrRequestGenerationRef.current) return;
 
       setToast({
         show: true,
-        message: `${totalCount} 件のOCR処理を開始しました`,
+        message: `${targetIds.length} 件のOCR処理を開始しました`,
         type: 'success',
       });
       setSelectedIds(new Set());
       await fetchFiles();
     } catch (error: any) {
       if (requestGeneration !== ocrRequestGenerationRef.current) return;
+
+      if (error.response?.status === 503 && error.apiErrorCode === 'endpoint_not_ready') {
+        setIsEndpointWarming(true);
+
+        if (warmingPollRef.current) clearInterval(warmingPollRef.current);
+        warmingPollRef.current = setInterval(async () => {
+          if (requestGeneration !== ocrRequestGenerationRef.current) {
+            if (warmingPollRef.current) {
+              clearInterval(warmingPollRef.current);
+              warmingPollRef.current = null;
+            }
+            return;
+          }
+
+          try {
+            const statusResponse = await api.get('/system/ocr-endpoint-status');
+
+            if (statusResponse.data.ready) {
+              if (warmingPollRef.current) {
+                clearInterval(warmingPollRef.current);
+                warmingPollRef.current = null;
+              }
+              setIsEndpointWarming(false);
+              void startOcrTargets(targetIds, requestGeneration);
+            }
+          } catch (pollError) {
+            console.error('ポーリングエラー:', pollError);
+          }
+        }, 10000);
+
+        return;
+      }
 
       console.error('OCR処理の開始に失敗しました:', error);
       setToast({
@@ -195,7 +182,7 @@ function Upload() {
   const startOcr = () => {
     const requestGeneration = ocrRequestGenerationRef.current + 1;
     ocrRequestGenerationRef.current = requestGeneration;
-    return startOcrTargets(ocrTargetIds, ocrTargetIds.length, requestGeneration);
+    return startOcrTargets(ocrTargetIds, requestGeneration);
   };
 
   // 一覧を更新

--- a/web/src/pages/upload/Upload.tsx
+++ b/web/src/pages/upload/Upload.tsx
@@ -16,6 +16,7 @@ import { ImageListFilterTabs } from "../../components/shared/ImageListFilterTabs
 import {
   applyFilter,
   getTopLevelFiles,
+  isParentDocument,
   normalizeDeletionTargets,
   normalizeOcrTargets,
   type FilterKey,
@@ -395,17 +396,24 @@ function Upload() {
     else if (total > 0 && page >= total) setPage(total - 1);
   }, [page, setPage, total]);
 
+  // 選択された leaf（親コンテナを除く子ページ / standalone）。カウント表示は全アクションで
+  // この粒度に統一する（親は表示用グルーピングなので数えない）。
+  const selectedLeaves = useMemo(
+    () => files.filter((file) => selectedIds.has(file.id) && !isParentDocument(file)),
+    [files, selectedIds]
+  );
+
   const confirmableSelectedIds = useMemo(
-    () => files
+    () => selectedLeaves
       .filter((file) =>
-        selectedIds.has(file.id) &&
         file.status === 'completed' &&
         !file.verificationCompleted
       )
       .map((file) => file.id),
-    [files, selectedIds]
+    [selectedLeaves]
   );
 
+  // 削除 API の呼び出し単位。親を指定すると子ページもカスケード削除される。
   const deletionTargetIds = useMemo(
     () => normalizeDeletionTargets(files, selectedIds),
     [files, selectedIds]
@@ -445,10 +453,10 @@ function Upload() {
     if (selectedIds.size === 0 || deletionTargetIds.length === 0) return;
     setBulkDeleteConfirmOpen(false);
     setBulkDeleting(true);
-    setToast({ show: true, message: `${selectedIds.size} 件を削除中...`, type: 'info' });
+    setToast({ show: true, message: `${selectedLeaves.length} 件を削除中...`, type: 'info' });
     try {
       await Promise.all(deletionTargetIds.map((id) => deleteImage(id)));
-      setToast({ show: true, message: `${selectedIds.size} 件のファイルを削除しました`, type: 'success' });
+      setToast({ show: true, message: `${selectedLeaves.length} 件のファイルを削除しました`, type: 'success' });
       setSelectedIds(new Set());
       fetchFiles();
     } catch (err) {
@@ -710,7 +718,7 @@ function Upload() {
                         : `${confirmableSelectedIds.length} 件を確認済みにする`}
                     </Button>
                   )}
-                  {selectedIds.size > 0 && (
+                  {selectedLeaves.length > 0 && (
                     <Button
                       variant="danger"
                       size="sm"
@@ -718,7 +726,7 @@ function Upload() {
                       disabled={bulkDeleting || bulkConfirming || isProcessing || isEndpointWarming}
                     >
                       <Trash2 size={14} className="mr-1" />
-                      {selectedIds.size} 件を削除
+                      {selectedLeaves.length} 件を削除
                     </Button>
                   )}
                 </div>
@@ -808,7 +816,7 @@ function Upload() {
         onClose={() => setBulkDeleteConfirmOpen(false)}
         onConfirm={executeBulkDelete}
         title="ファイルの削除"
-        message={`選択した ${selectedIds.size} 件のファイルを削除します。\nこの操作は取り消せません。`}
+        message={`選択した ${selectedLeaves.length} 件のファイルを削除します。\nこの操作は取り消せません。`}
         confirmText="削除"
         cancelText="キャンセル"
       />

--- a/web/src/utils/imageListHelpers.ts
+++ b/web/src/utils/imageListHelpers.ts
@@ -56,7 +56,7 @@ export interface ImageFamily {
   children: ImageFile[];
 }
 
-const isParentDocument = (file: ImageFile): boolean =>
+export const isParentDocument = (file: ImageFile): boolean =>
   file.pageProcessingMode === 'individual' &&
   !file.parentDocumentId &&
   (file.totalPages || 0) > 1;


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Backend consolidation of the OCR-start flow plus several list-view UI fixes. Grouped by topic below.

**Consolidate OCR start into a shared app-scoped pipeline**

The bulk "start OCR" and single re-process paths had drifted into two separate implementations with different status transitions and error handling, and the frontend had started firing one request per selected image. That bypassed the Step Functions Map concurrency limit and could flood the single-instance OCR endpoint. Now a shared `OcrService._start_pipeline` owns endpoint-readiness check, status transition, agent reset, a single Step Functions execution with all image ids, the 256KB cap, and rollback to prior status on failure. `POST /apps/{app_name}/jobs` accepts an optional `image_ids` list (omitted = all pending in the app; provided = those images, validated to belong to the app). The single `POST /images/{id}/process` route is kept for re-process/re-extract and becomes a thin wrapper. The frontend Upload screen now issues one batch call.

**Show "verifying" status without a completed flash**

When a usecase auto-runs agent verification, the image briefly showed "completed" before flipping to "verifying" because agent status was still idle when extraction finished. Extraction now sets agent status to processing before marking the image completed when the usecase will auto-run the agent. The enable/auto-run decision is extracted into a shared `should_run_agent` helper reused by the agent worker.

**Count list actions by selected leaf pages**

Action button counts were inconsistent for individual-page PDFs (the parent container was counted). Counts now use the selected leaf pages (children / standalone), excluding the display-only parent container, so OCR / delete / confirm counts are consistent.

**Render pagination arrow icons**

The pagination NavButton dropped its `children`, so the arrow icons never rendered. Fixed to render children.

Tests added for the OCR start pipeline (id resolution, cross-app rejection, status transition, rollback, endpoint-not-ready, dedup, single delegation) and for `should_run_agent`. Full backend suite passes; `npm run build` passes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.